### PR TITLE
Implementation of simple ImagePortlet to embed images into dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ work
 .classpath
 .project
 .settings
+.idea
+dashboard-view.iml
 nb-configuration.xml

--- a/src/main/java/hudson/plugins/view/dashboard/core/ImagePortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/core/ImagePortlet.java
@@ -1,0 +1,38 @@
+package hudson.plugins.view.dashboard.core;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.plugins.view.dashboard.DashboardPortlet;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.plugins.view.dashboard.Messages;
+
+/**
+ * Portlet displays image fetched from specified URL
+ *
+ * @author rmihael@gmail.com
+ */
+public class ImagePortlet extends DashboardPortlet {
+
+    private String url;
+
+    @DataBoundConstructor
+    public ImagePortlet(String name, String url) {
+        super(name);
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_Image();
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/view/dashboard/Messages.properties
+++ b/src/main/resources/hudson/plugins/view/dashboard/Messages.properties
@@ -20,3 +20,4 @@ Dashboard.Total=total
 Dashboard.Date=date
 Dashboard.Count=count
 Dashboard.SlavesStatistics=Slaves statistics
+Dashboard.Image=Image

--- a/src/main/resources/hudson/plugins/view/dashboard/core/ImagePortlet/config.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/ImagePortlet/config.jelly
@@ -1,0 +1,32 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Display name}">
+    <f:textbox name="portlet.name" field="name" default="${descriptor.getDisplayName()}" />
+  </f:entry>
+  <f:entry title="URL">
+    <f:textbox name="portlet.url" field="url" default="" />
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/view/dashboard/core/ImagePortlet/portlet.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/ImagePortlet/portlet.jelly
@@ -1,0 +1,29 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:dp="/hudson/plugins/view/dashboard" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <dp:decorate portlet="${it}" width="3">
+      <img src="${it.getUrl()}"/>
+  </dp:decorate>
+</j:jelly>


### PR DESCRIPTION
Hello.

I made a very simple portlet that does nothing except to pulling image by specified URL. In my project we found it very useful to publish graphs generated by plugins that doesn't provide dashboard integration. In particular we used it to display graphs from Violations plugin.

It would be nice to include this portlet into main branch. I'm ready to make some efforts to bring it up to your coding standards if I unintentionally violated any of them.
