### PR TITLE
New configuration parameters to JobsPortlet

### DIFF
--- a/src/main/java/hudson/plugins/view/dashboard/core/JobsPortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/core/JobsPortlet.java
@@ -1,7 +1,11 @@
 package hudson.plugins.view.dashboard.core;
 
+import java.util.List;
+
 import hudson.Extension;
+import hudson.model.TopLevelItem;
 import hudson.model.Descriptor;
+import hudson.model.Job;
 import hudson.plugins.view.dashboard.DashboardPortlet;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -15,9 +19,52 @@ import hudson.plugins.view.dashboard.Messages;
  */
 public class JobsPortlet extends DashboardPortlet {
 
+   private int columnCount = 3;
+   private boolean fillColumnFirst = false;
+
    @DataBoundConstructor
-   public JobsPortlet(String name) {
+   public JobsPortlet(String name,
+                      int columnCount,
+                      boolean fillColumnFirst) {
       super(name);
+      this.columnCount = columnCount;
+      this.fillColumnFirst = fillColumnFirst;
+   }
+   
+   public int getColumnCount() {
+      return this.columnCount <= 0 ? 3 : this.columnCount;
+   }
+
+   public int getRowCount() {
+      int s = this.getDashboard().getJobs().size();
+      int rowCount = s / this.columnCount;
+      if (s % this.columnCount > 0){
+         rowCount += 1;
+      }
+      return rowCount;
+   }
+
+   public boolean getFillColumnFirst() {
+      return this.fillColumnFirst;
+   }
+
+   public Job getJob(int curRow, int curColumun){
+      List<Job> jobs = this.getDashboard().getJobs();
+      int idx = 0;
+      // get grid coordinates from given params
+      if (this.fillColumnFirst){
+         idx = curRow + curColumun * this.getRowCount();
+         if (idx >= jobs.size()){
+            return null;
+         }
+      }
+      else {
+         idx = curColumun + curRow * this.columnCount;
+         if (idx >= jobs.size()){
+            return null;
+         }
+      }
+     return jobs.get(idx);
    }
 
    @Extension

--- a/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/config.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/config.jelly
@@ -1,0 +1,36 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Display name}">
+    <f:textbox name="portlet.name" field="name" default="${descriptor.getDisplayName()}" />
+  </f:entry>
+  <f:entry title="${%Number of columns}">
+    <f:textbox name="portlet.columnCount" field="columnCount" />
+  </f:entry>
+  <f:block>
+    <f:checkbox name="portlet.fillColumnFirst" field="fillColumnFirst" />
+    ${%Fill column first}
+  </f:block>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet.jelly
@@ -23,41 +23,36 @@ THE SOFTWARE.
 -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:dp="/hudson/plugins/view/dashboard" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <dp:decorate portlet="${it}" width="3">
-	  <j:set var="i" value="${1 - 1}"/>
-	  <j:while test="${i &lt; jobs.size()}">
-	  	<tr>
+  <j:set var="h" value="${it.rowCount}"/>
+  <j:set var="w" value="${it.columnCount}"/>
+  <dp:decorate portlet="${it}" width="${w}">
+    <j:set var="i" value="${1 - 1}"/>
+    <j:while test="${i &lt; h}">
+      <tr>
         <j:set var="j" value="${1 - 1}"/>
-	  		<j:while test="${i &lt; jobs.size() &amp;&amp; j &lt; 3}">
-          <j:set var="job" value="${jobs.get(i)}" />
-	  			<td style="border: 1px solid #bbb;">
-            <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
-              <a href="${job.shortUrl}build?delay=0sec">
-                <img src="${imagesURL}/16x16/clock.png"
-                     title="${%Schedule a build}" alt="${%Schedule a build}"
-                     border="0"
-                     align="middle"
-                     onclick="${job.parameterized ? null : 'return build(this)'}"
-                     style="float: right; clear: none;" />
-                <script>
-                     function build(img) {
-	    		new Ajax.Request(img.parentNode.href);
-	    		hoverNotification('${%Build scheduled}', img, -100);
-	    		return false;
-                     }
-                </script>						 
-              </a>
-            </j:if>
-            <dp:jobLink job="${job}"/>
-          </td>
-	    		<j:set var="i" value="${i + 1}"/>
-	    		<j:set var="j" value="${j + 1}"/>
-	  		</j:while>
-	  		<j:while test="${j &lt; 3}">
-	  			<td style="border: 1px solid #bbb;"></td>
-	    		<j:set var="j" value="${j + 1}"/>
-	  		</j:while>
-	  	</tr>
-	  </j:while>
+        <j:while test="${j &lt; w}">
+          <j:set var="job" value="${it.getJob(i, j)}" />
+          <j:if test="${!empty(job)}">
+            <td style="border: 1px solid #bbb;">
+              <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
+                <a href="${job.shortUrl}build?delay=0sec">
+                  <img src="${imagesURL}/16x16/clock.png"
+                       title="${%Schedule a build}" alt="${%Schedule a build}"
+                       border="0"
+                       align="middle"
+                       style="float: right; clear: none;" />
+                </a>
+              </j:if>
+              <dp:jobLink job="${job}"/>
+            </td>
+          </j:if>
+          <j:if test="${empty(job)}">
+            <td style="border: 1px solid #bbb;"></td>
+          </j:if>
+          <j:set var="j" value="${j + 1}"/>
+        </j:while>
+      </tr>
+      <j:set var="i" value="${i + 1}"/>
+    </j:while>
   </dp:decorate>
 </j:jelly>


### PR DESCRIPTION
Hello,

Here is a pull request to add the following configuration parameters to JobsPortlet:
- Number of columns
- Fill column first

![JobsPortletConfig](https://f.cloud.github.com/assets/1243537/73879/b0b52fb0-6066-11e2-8c8b-30ad1244f829.png)

If "Fill column first" is checked then jobs are inserted from top to bottom then from left to right. It can feel more natural for some users.

![JobsPortletFillCol1st](https://f.cloud.github.com/assets/1243537/73880/b64d9890-6066-11e2-84d8-90623c7b3772.png)

Cheers,
syl20bnr
