### PR TITLE
Job rebuild icons should use POST instead of GET requests.

### DIFF
--- a/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet.jelly
@@ -37,7 +37,15 @@ THE SOFTWARE.
                      title="${%Schedule a build}" alt="${%Schedule a build}"
                      border="0"
                      align="middle"
+                     onclick="${job.parameterized ? null : 'return build(this)'}"
                      style="float: right; clear: none;" />
+                <script>
+                     function build(img) {
+	    		new Ajax.Request(img.parentNode.href);
+	    		hoverNotification('${%Build scheduled}', img, -100);
+	    		return false;
+                     }
+                </script>						 
               </a>
             </j:if>
             <dp:jobLink job="${job}"/>

--- a/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/portlet.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/portlet.jelly
@@ -42,7 +42,15 @@ THE SOFTWARE.
                    title="${%Schedule a build}" alt="${%Schedule a build}"
                    border="0"
                    align="middle"
+                   onclick="${job.parameterized ? null : 'return build(this)'}"
                    style="float: right; clear: none;" />
+              <script>
+                function build(img) {
+                  new Ajax.Request(img.parentNode.href);
+                  hoverNotification('${%Build scheduled}', img, -100);
+                  return false;
+                }
+              </script>				   
             </a>
           </j:if>
           <dp:jobLink job="${job}" />


### PR DESCRIPTION
Job rebuild icons should use POST method instead of GET request after Jenkins version 1.502 (issue SECURITY-13).

Otherwise, it gives you the warning:
"You must use POST method to trigger builds. (From scripts you may instead pass a per-project authentication token, or authenticate with your API token.) If you see this page, it may be because a plugin offered a GET link; file a bug report for that plugin."
