### PR TITLE
Added parameter "Show only Failed Jobs" to Unstable Jobs Portlet.

### DIFF
--- a/src/main/java/hudson/plugins/view/dashboard/core/UnstableJobsPortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/core/UnstableJobsPortlet.java
@@ -28,12 +28,15 @@ import hudson.plugins.view.dashboard.Messages;
  */
 public class UnstableJobsPortlet extends DashboardPortlet {
 
+   private boolean showOnlyFailedJobs = false;
+   
    private static final Collection<ListViewColumn> COLUMNS =
            Arrays.asList(new StatusColumn(), new WeatherColumn(), new JobColumn());
 
    @DataBoundConstructor
-   public UnstableJobsPortlet(String name) {
+   public UnstableJobsPortlet(String name, boolean showOnlyFailedJobs) {
       super(name);
+	  this.showOnlyFailedJobs = showOnlyFailedJobs;
    }
 
    /**
@@ -47,8 +50,12 @@ public class UnstableJobsPortlet extends DashboardPortlet {
              Job job = (Job) item;
              Run run = job.getLastCompletedBuild();
 
-             if (run != null && Result.UNSTABLE.isBetterOrEqualTo(run.getResult())) {
-                unstableJobs.add(job);
+             if (run != null) {
+                Result expected = this.showOnlyFailedJobs ? Result.FAILURE : Result.UNSTABLE;
+
+                if (expected.isBetterOrEqualTo(run.getResult())) {
+                   unstableJobs.add(job);
+                }
              }
          }
       }
@@ -60,6 +67,10 @@ public class UnstableJobsPortlet extends DashboardPortlet {
       return COLUMNS;
    }
 
+   public boolean isShowOnlyFailedJobs() {
+      return this.showOnlyFailedJobs;
+   }
+	
    @Extension
    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
 

--- a/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/config.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/config.jelly
@@ -1,0 +1,33 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Display name}">
+    <f:textbox name="portlet.name" field="name" default="${descriptor.getDisplayName()}" />
+  </f:entry>
+  <f:entry title="${%Parameters}">
+    <f:checkbox name="portlet.showOnlyFailedJobs" field="showOnlyFailedJobs" />
+	${%Show only Failed Jobs} <br/>
+  </f:entry>
+</j:jelly>


### PR DESCRIPTION
"Now it's possible to have a view that shows only Failed Jobs (red) instead of Failed and Unstable Jobs (red+yellow).
Depending on your job role, it's very good to distinguish between jobs that don't worked (authentication, slaves connection, directory creating or infrastructure issues) - and jobs that worked, but just not as expected (usually XUnit test failures).

Signed-off-by: Bruno Candido Volpato da Cunha brunocvcunha@gmail.com"

Thank you.

Regards,
Bruno
