### PR TITLE
Fix test trend chart for TestNG test results

### DIFF
--- a/src/main/java/hudson/plugins/view/dashboard/test/TestUtil.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/TestUtil.java
@@ -53,7 +53,7 @@ public class TestUtil {
    }
 
    public static TestResult getTestResult(Run run) {
-      TestResultAction tra = run.getAction(TestResultAction.class);
+      AbstractTestResultAction tra = run.getAction(AbstractTestResultAction.class);
       if (tra != null) {
          return new TestResult(run.getParent(), tra.getTotalCount(), tra.getFailCount(), tra.getSkipCount());
       } 


### PR DESCRIPTION
Using more generic AbstractTestResultAction instead of TestResultAction which is specific to JUnit results generated by Jenkins.

Built and tested to make sure that the graph shows up correctly
