### PR TITLE
TestStatisticsPortlet config.jelly: the reference to the instance of the portlet was using the wrong syntax

### DIFF
--- a/src/main/resources/hudson/plugins/view/dashboard/test/TestStatisticsPortlet/config.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/test/TestStatisticsPortlet/config.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <f:entry title="${%Display name}">
     <f:textbox name="portlet.name" field="name" default="${descriptor.getDisplayName()}" />
   </f:entry>
-  <f:optionalBlock name="useBackgroundColors" title="${%Background Colors}" checked="${portlet.isUseBackgroundColors()}" inline="true">
+  <f:optionalBlock name="useBackgroundColors" title="${%Background Colors}" checked="${instance.isUseBackgroundColors()}" inline="true">
       <f:entry title="${%Success Color} (${%in hex})">
 	    <f:textbox name="successColor" field="successColor" default="71E66D" />
 	  </f:entry>


### PR DESCRIPTION
minor nuisance bug that the config page did not remember the checked setting for using the background colors. 
