### PR TITLE
Fixed issue where dashboard view would not work inside a folder.

### DIFF
--- a/src/main/resources/hudson/plugins/view/dashboard/jobLink.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/jobLink.jelly
@@ -39,5 +39,5 @@ THE SOFTWARE.
       alt="${job.buildHealth.description}"
       title="${job.buildHealth.description}" />
    <!--t:jobLink job="${job}"/-->
-   <a href="${job.url}" class="model-link">${job.fullDisplayName}</a>
+   <a href="${job.absoluteUrl}" class="model-link">${job.fullDisplayName}</a>
 </j:jelly>


### PR DESCRIPTION
If a view was created inside a folder, the jobLink would fail to properly provide the correct url.
