### PR TITLE
[FIXED JENKINS-12205] : show test statistics for Matrix Jobs

### DIFF
--- a/src/test/java/hudson/plugins/view/dashboard/test/TestSummaryForMatrixJobs.java
+++ b/src/test/java/hudson/plugins/view/dashboard/test/TestSummaryForMatrixJobs.java
@@ -1,0 +1,60 @@
+package hudson.plugins.view.dashboard.test;
+
+import hudson.Launcher;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.TextAxis;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.TopLevelItem;
+import hudson.tasks.junit.JUnitResultArchiver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TestSummaryForMatrixJobs {
+   @Rule
+   public JenkinsRule jenkins = new JenkinsRule();
+
+   private MatrixProject matrixProject;
+
+   @Before
+   public void createMatrixJob() throws IOException {
+      matrixProject = jenkins.createMatrixProject("top");
+      matrixProject.getAxes().add(new TextAxis("param", "one", "two"));
+      matrixProject.getBuildersList().add(new TestBuilder() {
+         @Override
+         public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            build.getWorkspace().child("testresult.xml").copyFrom(TestSummaryForMatrixJobs.class.getResource("/hudson/plugins/view/dashboard/test_failure.xml"));
+            return true;
+         }
+      });
+      matrixProject.getPublishersList().add(new JUnitResultArchiver("testresult.xml", true, null));
+   }
+
+   @Test
+   public void summaryIncludesMatrixJobs() throws Exception {
+      MatrixBuild result = matrixProject.scheduleBuild2(0).get();
+      jenkins.assertBuildStatus(Result.UNSTABLE, result);
+
+      TestResultSummary testSummary = TestUtil.getTestResultSummary(Collections.singleton((TopLevelItem) matrixProject));
+      assertThat(testSummary.getFailed(), is((2)));
+      assertThat(testSummary.getSuccess(), is((2)));
+   }
+
+   @After
+   public void cleanupMatrixJob() throws IOException, InterruptedException {
+      matrixProject.delete();
+   }
+
+}

--- a/src/test/resources/hudson/plugins/view/dashboard/test_failure.xml
+++ b/src/test/resources/hudson/plugins/view/dashboard/test_failure.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite errors="0" failures="1" hostname="anniesue" name="com.luciad.format.aixmcommon.view.lightspeed.TLspAIXMStylerAcceptanceTest" skipped="0" tests="2" time="12.829" timestamp="2015-09-14T14:37:11">
+    <properties/>
+    <testcase classname="test" name="failure" time="0.376">
+        <failure message="description" type="junit.framework.AssertionFailedError">
+            detail message
+        </failure>
+    </testcase>
+    <testcase classname="test.case" name="success" time="0.893" />
+    <system-out><![CDATA[System out
+]]></system-out>
+    <system-err><![CDATA[System err
+]]></system-err>
+</testsuite>


### PR DESCRIPTION
Recent versions of MatrixProject no longer include the test results of their child jobs. Iterate over them manually.

This approach keeps the plugin compatible with older versions of Jenkins (i.e. no changes in the pom.xml)