### PR TITLE
[FIX JENKINS-29690] Explicitly specify ball size

### DIFF
--- a/src/main/resources/hudson/plugins/view/dashboard/stats/StatBuilds/statbuilds.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/stats/StatBuilds/statbuilds.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
 				</j:forEach>
 				<j:forEach var="col" items="${statsBuild}">
 					<tr>
-						<t:ballColorTd it="${col.key}" />
+						<t:ballColorTd it="${col.key}" iconSizeClass="icon-sm" />
 						<td>${col.key.description}</td>
 						<td>${col.value}</td>
 						<td>${it.roundFloatDecimal((col.value/nBuilds)*100)}</td>


### PR DESCRIPTION
Looks like something went wrong when that was converted into CSS. This fixes the issue of the icons in the builds portlet not showing up on 1.590+ or so.