### PR TITLE
Add option to test statistics to ignore blank jobs.

### DIFF
--- a/src/main/java/hudson/plugins/view/dashboard/test/TestStatisticsPortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/TestStatisticsPortlet.java
@@ -24,18 +24,33 @@ public class TestStatisticsPortlet extends DashboardPortlet {
 	private String skippedColor;
 	private String successColor;
 	private String failureColor;
+	private boolean hideBlankJobs;
 
-	@DataBoundConstructor
-	public TestStatisticsPortlet(String name, String successColor, String failureColor, String skippedColor, boolean useBackgroundColors) {
+	public TestStatisticsPortlet(
+            String name, String successColor, String failureColor, String skippedColor,
+            boolean useBackgroundColors) {
 		super(name);
 		this.successColor = successColor;
 		this.failureColor = failureColor;
 		this.skippedColor = skippedColor;
 		this.useBackgroundColors = useBackgroundColors;
+		this.hideBlankJobs = false;
+        }
+
+	@DataBoundConstructor
+	public TestStatisticsPortlet(
+            String name, String successColor, String failureColor, String skippedColor,
+            boolean useBackgroundColors, boolean hideBlankJobs) {
+		super(name);
+		this.successColor = successColor;
+		this.failureColor = failureColor;
+		this.skippedColor = skippedColor;
+		this.useBackgroundColors = useBackgroundColors;
+		this.hideBlankJobs = hideBlankJobs;
 	}
 
 	public TestResultSummary getTestResultSummary(Collection<TopLevelItem> jobs) {
-		return TestUtil.getTestResultSummary(jobs);
+		return TestUtil.getTestResultSummary(jobs, hideBlankJobs);
 	}
 
 	public String format(DecimalFormat df, double val) {
@@ -47,7 +62,11 @@ public class TestStatisticsPortlet extends DashboardPortlet {
 		}
 		return df.format(val);
 	}
-	
+
+    public boolean isHideBlankJobs() {
+        return hideBlankJobs;
+    }
+
 	public boolean isUseBackgroundColors() {
 		return useBackgroundColors;
 	}
@@ -76,8 +95,12 @@ public class TestStatisticsPortlet extends DashboardPortlet {
 		}
 		return successColor;
 	}
-	
-	public void setUseBackgroundColors(boolean useBackgroundColors) {
+
+    public void setHideBlankJobs(boolean hideBlankJobs) {
+        this.hideBlankJobs = hideBlankJobs;
+    }
+
+    public void setUseBackgroundColors(boolean useBackgroundColors) {
 		this.useBackgroundColors = useBackgroundColors;
 	}
 	

--- a/src/main/java/hudson/plugins/view/dashboard/test/TestUtil.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/TestUtil.java
@@ -20,6 +20,10 @@ public class TestUtil {
     * @return
     */
    public static TestResultSummary getTestResultSummary(Collection<TopLevelItem> jobs) {
+       return getTestResultSummary(jobs, false);
+   }
+
+   public static TestResultSummary getTestResultSummary(Collection<TopLevelItem> jobs, boolean hideBlanks) {
       TestResultSummary summary = new TestResultSummary();
 
       for (TopLevelItem item : jobs) {
@@ -28,21 +32,21 @@ public class TestUtil {
 
             for (Job job : mp.getAllJobs()) {
                if (job != mp) { //getAllJobs includes the parent job too, so skip that
-                  summarizeJob(job, summary);
+                  summarizeJob(job, summary, hideBlanks);
                }
             }
          }
          else if (item instanceof Job) {
             Job job = (Job) item;
-            summarizeJob(job, summary);
+            summarizeJob(job, summary, hideBlanks);
          }
       }
 
       return summary;
    }
 
-   private static void summarizeJob(Job job, TestResultSummary summary) {
-      boolean addBlank = true;
+   private static void summarizeJob(Job job, TestResultSummary summary, boolean hideBlanks) {
+      boolean addBlank = !hideBlanks;
       TestResultProjectAction testResults = job.getAction(TestResultProjectAction.class);
 
       if (testResults != null) {

--- a/src/main/resources/hudson/plugins/view/dashboard/test/TestStatisticsPortlet/config.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/test/TestStatisticsPortlet/config.jelly
@@ -26,6 +26,9 @@ THE SOFTWARE.
   <f:entry title="${%Display name}">
     <f:textbox name="portlet.name" field="name" default="${descriptor.getDisplayName()}" />
   </f:entry>
+  <f:entry title="${%Hide blank jobs}" field="hideBlankJobs">
+    <f:checkbox />
+  </f:entry>
   <f:optionalBlock name="useBackgroundColors" title="${%Background Colors}" checked="${instance.isUseBackgroundColors()}" inline="true">
       <f:entry title="${%Success Color} (${%in hex})">
 	    <f:textbox name="successColor" field="successColor" default="71E66D" />


### PR DESCRIPTION
I would like to add an option to the test statistic charts to only return results for jobs which contain values.  This would result in a report similar to the Cobertura reports for the dashboard views.