### PR TITLE
simplify MAX_BUILDS logic

### DIFF
--- a/src/main/java/hudson/plugins/view/dashboard/stats/StatBuilds.java
+++ b/src/main/java/hudson/plugins/view/dashboard/stats/StatBuilds.java
@@ -43,16 +43,11 @@ public class StatBuilds extends DashboardPortlet{
 			if (job instanceof Job) {
 				// Build statistics
                 List<Run> builds = ((Job) job).getBuilds().limit(MAX_BUILDS);
-                if (builds.isEmpty()) {
-                    colStatBuilds.put(BallColor.GREY.noAnime(),
-                                      colStatBuilds.get(BallColor.GREY) + 1);
-                    } else {
-                    //loop over builds
-                    for (Run build : builds) {
-                        BallColor bColor = build.getIconColor();
-                        if(bColor != null && bColor.noAnime() != null && colStatBuilds.get(bColor) != null) {
-                            colStatBuilds.put(bColor.noAnime(), colStatBuilds.get(bColor) + 1);
-                        }
+                //loop over builds
+                for (Run build : builds) {
+                    BallColor bColor = build.getIconColor();
+                    if(bColor != null && bColor.noAnime() != null && colStatBuilds.get(bColor) != null) {
+                        colStatBuilds.put(bColor.noAnime(), colStatBuilds.get(bColor) + 1);
                     }
                 }
             }

--- a/src/main/java/hudson/plugins/view/dashboard/stats/StatBuilds.java
+++ b/src/main/java/hudson/plugins/view/dashboard/stats/StatBuilds.java
@@ -42,26 +42,21 @@ public class StatBuilds extends DashboardPortlet{
 		for (TopLevelItem job : jobs) {
 			if (job instanceof Job) {
 				// Build statistics
-                // With a 1.507+ dep and a fix of JENKINS-18065 could use simply: job.getBuilds().limit(MAX_BUILDS)
-				SortedMap<Integer,Run> buildMap = ((Job) job).getBuildsAsMap();
-                if (!buildMap.isEmpty()) {
-                    Collection<Run> builds = buildMap.headMap(buildMap.firstKey() - MAX_BUILDS).values();
-                    if (builds.isEmpty()) {
-                        colStatBuilds.put(BallColor.GREY.noAnime(), colStatBuilds
-                                .get(BallColor.GREY) + 1);
+                List<Run> builds = ((Job) job).getBuilds().limit(MAX_BUILDS);
+                if (builds.isEmpty()) {
+                    colStatBuilds.put(BallColor.GREY.noAnime(),
+                                      colStatBuilds.get(BallColor.GREY) + 1);
                     } else {
-                        //loop over builds
-                        for (Run build : builds) {
-                            BallColor bColor = build.getIconColor();
-                            if(bColor != null && bColor.noAnime() != null && colStatBuilds.get(bColor) != null){
-                                colStatBuilds.put(bColor.noAnime(), colStatBuilds
-                                    .get(bColor) + 1);
-                            }
+                    //loop over builds
+                    for (Run build : builds) {
+                        BallColor bColor = build.getIconColor();
+                        if(bColor != null && bColor.noAnime() != null && colStatBuilds.get(bColor) != null) {
+                            colStatBuilds.put(bColor.noAnime(), colStatBuilds.get(bColor) + 1);
                         }
                     }
                 }
-			}
-		}
+            }
+        }
 		return colStatBuilds;
 	}
 	

--- a/src/test/java/hudson/plugins/view/dashboard/stats/StatBuildsTest.java
+++ b/src/test/java/hudson/plugins/view/dashboard/stats/StatBuildsTest.java
@@ -20,11 +20,11 @@ public class StatBuildsTest {
     @Test public void avoidEagerLoading() throws Exception {
         final FreeStyleProject p = j.createFreeStyleProject();
         RunLoadCounter.prepare(p);
-        for (int i = 0; i < 15; i++) {
+        for (int i = 0; i < 25; i++) {
             j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         }
         final StatBuilds stats = new StatBuilds("-");
-        assertEquals(StatBuilds.MAX_BUILDS, RunLoadCounter.assertMaxLoads(p, StatBuilds.MAX_BUILDS + /* AbstractLazyLoadRunMap.headMap actually loads start, alas */1, new Callable<Integer>() {
+        assertEquals(StatBuilds.MAX_BUILDS, RunLoadCounter.assertMaxLoads(p, StatBuilds.MAX_BUILDS + /* margin for AbstractLazyLoadRunMap.headMap */2, new Callable<Integer>() {
             public Integer call() throws Exception {
                 return stats.getBuildStat(Collections.<TopLevelItem>singletonList(p)).get(BallColor.BLUE);
             }


### PR DESCRIPTION
Since this plugin already depends on jenkins > 1.507 the code can take
advantage of a straight `getBuilds` and rely on jenkin's own limit
logic.

This change was motivated by anecdotal observations that when the
dashboard was slow to load, the thread was busy in this class. While
this is cleaner and satisfies a todo, I am unsure if it is any faster
or lazier in practice.
