### PR TITLE
Ensure that ${jobs} is really a Collection<Job>

### DIFF
--- a/src/main/resources/hudson/plugins/view/dashboard/Dashboard/main.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/Dashboard/main.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
     </j:when>
     <j:otherwise>
       	<st:include page="viewTabs.jelly" it="${it.owner.viewsTabBar}" />
-    	<j:set var="jobs" value="${it.items}"/>
+    	<j:set var="jobs" value="${it.jobs}"/>
 
     	<j:choose>
     	  <j:when test="${empty(it.rightPortlets)}">


### PR DESCRIPTION
Similar to JENKINS-21578 and PR #23

Example problem:

```
WARNING: Caught exception evaluating: it.getTotal(jobs) in /jenkins/. Reason: java.lang.ClassCastException: com.github.mjdetullio.jenkins.plugins.multibranch.MavenMultiBranchProject cannot be cast to hudson.model.Job
                java.lang.ClassCastException: com.github.mjdetullio.jenkins.plugins.multibranch.MavenMultiBranchProject cannot be cast to hudson.model.Job
                        at hudson.plugins.analysis.collector.dashboard.WarningsTablePortlet.getTotal(WarningsTablePortlet.java:366)
                        at sun.reflect.GeneratedMethodAccessor410.invoke(Unknown Source)
                        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                        at java.lang.reflect.Method.invoke(Method.java:497)
```