### PR TITLE
Hide tabbar and margins of the main-panel in the fullscreen view

### DIFF
--- a/src/main/webapp/css/full_screen.css
+++ b/src/main/webapp/css/full_screen.css
@@ -2,3 +2,11 @@
 #side-panel, #top-panel, #footer, #top-nav, #view-message, #viewList {
     display: none;
 }
+
+#main-panel {
+    margin-left: 0 !important;
+}
+
+div.tabBarFrame {
+    display: none;
+}


### PR DESCRIPTION
Hi there,

The current version of this great plugin in the full screen view does not remove margins of the main-panel as well as retains tab bar making the UI looking like the following 

![jenkins_dashboard_empty_area](https://cloud.githubusercontent.com/assets/1523889/20531410/1d86bd1a-b0f0-11e6-83b5-792f68653b9e.png)

... and with the style provided by this PR, there are no empty areas and tab bars in the full screen mode

![jenkins_dashboard_changed_style](https://cloud.githubusercontent.com/assets/1523889/20531461/49a35110-b0f0-11e6-9949-04cf03786a78.png)
