### PR TITLE
[JENKINS-43863] Improve PCT support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Dashboard+View</url>
 
   <properties>
-    <jenkins.version>1.554.1</jenkins.version>
-    <findbugs.failOnError>false</findbugs.failOnError> <!-- TODO fix -->
+    <jenkins.version>1.580.1</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <developers>
@@ -65,7 +65,18 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>2.10</version> <!-- last compatible with 1.554.x -->
+      <version>2.13</version> <!-- last compatible with 1.580.1 -->
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mailer</artifactId>
+      <version>1.17</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
[JENKINS-43863](https://issues.jenkins-ci.org/browse/JENKINS-43863)

- Bump Jenkins version and set appropriate java.level.
- Include needed dependencies.

@reviewbybees esp. @andresrc @jglick @petehayes @mambu 