### PR TITLE
Added a licensing definition to the Maven project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
   <licenses>
     <license>
-      <name>The MIT License</name>
+      <name>MIT License</name>
       <distribution>repo</distribution>
       <url>https://opensource.org/licenses/MIT</url>
     </license>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,13 @@
     <tag>HEAD</tag>
   </scm>
 
+  <licenses>
+    <license>
+      <name>The MIT License</name>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <license>
       <name>The MIT License</name>
       <distribution>repo</distribution>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
 


### PR DESCRIPTION
In order to meet the [prerequisites](https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Prerequisites) of plugin hosting in the Jenkins Organization, I'm adding the licensing definition in the Maven project.

@reviewbybees, What do you think?
