### PR TITLE
Add missing repository definitions to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,20 @@
     <java.level>8</java.level>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <!-- For RequireUpperBoundDeps -->
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Setting these repositories is common for Jenkins plugins.

Otherwise dependencies and plugins cannot be resolved if there is no central configuration provided elsewhere.