### PR TITLE
Use allItems since order doesn't matter

### DIFF
--- a/src/main/java/hudson/plugins/view/dashboard/stats/StatSlaves.java
+++ b/src/main/java/hudson/plugins/view/dashboard/stats/StatSlaves.java
@@ -6,7 +6,6 @@ import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.plugins.view.dashboard.DashboardPortlet;
 import hudson.plugins.view.dashboard.Messages;
-import java.util.List;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
@@ -33,7 +32,7 @@ public class StatSlaves extends DashboardPortlet {
     AgentStats(Jenkins j) {
       agents = j.getNodes().size();
       countAgents(j.getComputers());
-      tasksInQueue = j.getQueue().getApproximateItemsQuickly().size();
+      tasksInQueue = j.getQueue().getItems().length;
       runningJobs = countRunningJobs(j);
     }
 
@@ -51,9 +50,9 @@ public class StatSlaves extends DashboardPortlet {
     }
 
     private int countRunningJobs(Jenkins j) {
-      List<Job> jobs = j.getAllItems(Job.class);
+      // TODO: Might be a faster way to get this info from the computers
       int countRunningJobs = 0;
-      for (Job job : jobs) {
+      for (Job job : j.allItems(Job.class)) {
         if (job.isBuilding()) {
           countRunningJobs++;
         }

--- a/src/main/java/hudson/plugins/view/dashboard/stats/StatSlaves.java
+++ b/src/main/java/hudson/plugins/view/dashboard/stats/StatSlaves.java
@@ -6,6 +6,8 @@ import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.plugins.view.dashboard.DashboardPortlet;
 import hudson.plugins.view.dashboard.Messages;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
@@ -52,9 +54,12 @@ public class StatSlaves extends DashboardPortlet {
     private int countRunningJobs(Jenkins j) {
       // TODO: Might be a faster way to get this info from the computers
       int countRunningJobs = 0;
-      for (Job job : j.allItems(Job.class)) {
-        if (job.isBuilding()) {
-          countRunningJobs++;
+      //We don't really care about security here as all this returns is a count
+      try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
+        for (Job job : j.allItems(Job.class)) {
+          if (job.isBuilding()) {
+            countRunningJobs++;
+          }
         }
       }
       return countRunningJobs;


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

`allItems` is lazily loaded and doesn't do any sorting so it should be much more efficient.
Stop using approximate queue items since its deprecated