### PR TITLE
[JENKINS-56527] Add support for JCasC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,28 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>1.36</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <version>1.36</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jsoup</groupId>
+          <artifactId>jsoup</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jenkins-ci.main</groupId>
+          <artifactId>jenkins-test-harness</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/hudson/plugins/view/dashboard/Dashboard.java
+++ b/src/main/java/hudson/plugins/view/dashboard/Dashboard.java
@@ -10,19 +10,21 @@ import hudson.model.Job;
 import hudson.model.ListView;
 import hudson.model.TopLevelItem;
 import hudson.model.ViewDescriptor;
+import jenkins.security.stapler.StaplerDispatchable;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import javax.servlet.ServletException;
-import jenkins.security.stapler.StaplerDispatchable;
-import net.sf.json.JSONObject;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * View that can be customized with portlets to show the selected jobs information in various ways.
@@ -61,6 +63,7 @@ public class Dashboard extends ListView {
   }
 
   /** @since 2.13 */
+  @DataBoundSetter
   public void setIncludeStdJobList(boolean includeStdJobList) {
     this.includeStdJobList = includeStdJobList;
   }
@@ -89,12 +92,52 @@ public class Dashboard extends ListView {
     return bottomPortlets;
   }
 
-  public String getLeftPortletWidth() {
+  public synchronized String getLeftPortletWidth() {
     return leftPortletWidth;
   }
 
-  public String getRightPortletWidth() {
+  public synchronized String getRightPortletWidth() {
     return rightPortletWidth;
+  }
+
+  @DataBoundSetter
+  public synchronized void setUseCssStyle(boolean useCssStyle) {
+    this.useCssStyle = useCssStyle;
+  }
+
+  @DataBoundSetter
+  public void setHideJenkinsPanels(boolean hideJenkinsPanels) {
+    this.hideJenkinsPanels = hideJenkinsPanels;
+  }
+
+  @DataBoundSetter
+  public synchronized void setLeftPortletWidth(String leftPortletWidth) {
+    this.leftPortletWidth = leftPortletWidth;
+  }
+
+  @DataBoundSetter
+  public synchronized void setRightPortletWidth(String rightPortletWidth) {
+    this.rightPortletWidth = rightPortletWidth;
+  }
+
+  @DataBoundSetter
+  public void setLeftPortlets(List<DashboardPortlet> leftPortlets) {
+    this.leftPortlets = leftPortlets;
+  }
+
+  @DataBoundSetter
+  public void setRightPortlets(List<DashboardPortlet> rightPortlets) {
+    this.rightPortlets = rightPortlets;
+  }
+
+  @DataBoundSetter
+  public void setTopPortlets(List<DashboardPortlet> topPortlets) {
+    this.topPortlets = topPortlets;
+  }
+
+  @DataBoundSetter
+  public void setBottomPortlets(List<DashboardPortlet> bottomPortlets) {
+    this.bottomPortlets = bottomPortlets;
   }
 
   public String getPortletUrl(DashboardPortlet portlet) {

--- a/src/main/java/hudson/plugins/view/dashboard/DashboardPortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/DashboardPortlet.java
@@ -6,10 +6,11 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.ModelObject;
 import hudson.model.TopLevelItem;
-import java.util.Comparator;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.Comparator;
 
 /**
  * Report that can summarize project data across multiple projects and display the resulting data.
@@ -36,7 +37,7 @@ public abstract class DashboardPortlet
   public Dashboard getDashboard() {
     // TODO Can the dashboard instance be a field on this class -- parent?
     StaplerRequest req = Stapler.getCurrentRequest();
-    return req.findAncestorObject(Dashboard.class);
+    return req != null ? req.findAncestorObject(Dashboard.class) : null;
   }
 
   public String getDisplayName() {

--- a/src/main/java/hudson/plugins/view/dashboard/core/IframePortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/core/IframePortlet.java
@@ -5,10 +5,9 @@ import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.plugins.view.dashboard.DashboardPortlet;
 import hudson.plugins.view.dashboard.Messages;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Iterator;
-
-import org.kohsuke.stapler.DataBoundConstructor;
 
 public class IframePortlet extends DashboardPortlet {
 
@@ -41,7 +40,7 @@ public class IframePortlet extends DashboardPortlet {
 	}
 
 	private void overridePlaceholdersInUrl() {
-		if (iframeSource != null) {
+		if (iframeSource != null && getDashboard() != null) {
 			effectiveUrl = iframeSource.replaceAll("\\$\\{viewName\\}",
 					getDashboard().getViewName());
 			effectiveUrl = effectiveUrl.replaceAll("\\$\\{jobsList\\}",

--- a/src/main/java/hudson/plugins/view/dashboard/core/IframePortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/core/IframePortlet.java
@@ -40,11 +40,13 @@ public class IframePortlet extends DashboardPortlet {
 	}
 
 	private void overridePlaceholdersInUrl() {
-		if (iframeSource != null && getDashboard() != null) {
-			effectiveUrl = iframeSource.replaceAll("\\$\\{viewName\\}",
-					getDashboard().getViewName());
-			effectiveUrl = effectiveUrl.replaceAll("\\$\\{jobsList\\}",
-					jobsListAsString());
+		if (iframeSource != null) {
+			if (getDashboard() != null) {
+				effectiveUrl = iframeSource.replaceAll("\\$\\{viewName\\}", getDashboard().getViewName());
+				effectiveUrl = effectiveUrl.replaceAll("\\$\\{jobsList\\}", jobsListAsString());
+			} else {
+				effectiveUrl = iframeSource;
+			}
 		} else {
 			effectiveUrl = null;
 		}

--- a/src/main/java/hudson/plugins/view/dashboard/test/TestTrendChart.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/TestTrendChart.java
@@ -12,12 +12,9 @@ import hudson.util.ColorPalette;
 import hudson.util.DataSetBuilder;
 import hudson.util.EnumConverter;
 import hudson.util.Graph;
+import hudson.util.ListBoxModel;
 import hudson.util.ShiftedCategoryAxis;
 import hudson.util.StackedAreaRenderer2;
-import java.awt.Color;
-import java.util.Comparator;
-import java.util.Map;
-import java.util.TreeMap;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryAxis;
@@ -32,6 +29,11 @@ import org.joda.time.LocalDate;
 import org.joda.time.chrono.GregorianChronology;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Stapler;
+
+import java.awt.Color;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class TestTrendChart extends DashboardPortlet {
 
@@ -68,13 +70,13 @@ public class TestTrendChart extends DashboardPortlet {
 
   @DataBoundConstructor
   public TestTrendChart(
-      String name, int graphWidth, int graphHeight, String display, int dateRange, int dateShift) {
+    String name, int graphWidth, int graphHeight, DisplayStatus displayStatus, int dateRange, int dateShift) {
     super(name);
     this.graphWidth = graphWidth;
     this.graphHeight = graphHeight;
     this.dateRange = dateRange;
     this.dateShift = dateShift;
-    this.displayStatus = display != null ? DisplayStatus.valueOf(display) : DisplayStatus.ALL;
+    this.displayStatus = displayStatus;
     DashboardLog.debug("TestTrendChart", "ctor");
   }
 
@@ -94,23 +96,7 @@ public class TestTrendChart extends DashboardPortlet {
     return graphHeight <= 0 ? 220 : graphHeight;
   }
 
-  public String getDisplayStatus() {
-    if (displayStatus == null) {
-      displayStatus = DisplayStatus.ALL;
-      DashboardLog.info("TestTrendChart", "display is null - setting to ALL");
-    }
-    return displayStatus.getDescription();
-  }
-
-  public void setDisplayStatus(String s) {
-    displayStatus = DisplayStatus.valueOf(s);
-  }
-
-  public DisplayStatus getDisplayStatusEnum() {
-    if (displayStatus == null) {
-      displayStatus = DisplayStatus.ALL;
-      DashboardLog.info("TestTrendChart", "display is null - setting to ALL");
-    }
+  public DisplayStatus getDisplayStatus() {
     return displayStatus;
   }
 
@@ -237,7 +223,7 @@ public class TestTrendChart extends DashboardPortlet {
         StackedAreaRenderer ar = new StackedAreaRenderer2();
         plot.setRenderer(ar);
 
-        switch (getDisplayStatusEnum()) {
+        switch (getDisplayStatus()) {
           case SUCCESS:
             ar.setSeriesPaint(0, ColorPalette.BLUE);
             break;
@@ -267,7 +253,7 @@ public class TestTrendChart extends DashboardPortlet {
     for (Map.Entry<LocalDate, TestResultSummary> entry : summaries.entrySet()) {
       LocalDateLabel label = new LocalDateLabel(entry.getKey());
 
-      switch (getDisplayStatusEnum()) {
+      switch (getDisplayStatus()) {
         case SUCCESS:
           dsb.add(entry.getValue().getSuccess(), Messages.Dashboard_Total(), label);
           break;
@@ -310,6 +296,24 @@ public class TestTrendChart extends DashboardPortlet {
     @Override
     public String getDisplayName() {
       return Messages.Dashboard_TestTrendChart();
+    }
+
+    public DisplayStatus getDefaultDisplayStatus() {
+      return DisplayStatus.ALL;
+    }
+
+    /**
+     * Fills the jobExecutionMode drop-down menu.
+     *
+     * @return the jobExecutionMode items
+     */
+    public ListBoxModel doFillDisplayStatusItems() {
+      final ListBoxModel items = new ListBoxModel();
+      items.add(DisplayStatus.ALL.getDescription(), DisplayStatus.ALL.getName());
+      items.add(DisplayStatus.SUCCESS.getDescription(), DisplayStatus.SUCCESS.getName());
+      items.add(DisplayStatus.FAILED.getDescription(), DisplayStatus.FAILED.getName());
+      items.add(DisplayStatus.SKIPPED.getDescription(), DisplayStatus.SKIPPED.getName());
+      return items;
     }
   }
 }

--- a/src/main/resources/hudson/plugins/view/dashboard/test/TestTrendChart/config.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/test/TestTrendChart/config.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Display name}">
     <f:textbox name="portlet.name" field="name" default="${descriptor.getDisplayName()}" />
   </f:entry>
@@ -33,29 +33,8 @@ THE SOFTWARE.
   <f:entry title="${%Graph height}">
     <f:textbox name="portlet.graphHeight" field="graphHeight" default="220" />
   </f:entry>
-  <!-- This does not set the variable -->
-  <!--f:entry title="Display" field="displayStatus">
-     <f:enum>${it.description}</f:enum>
-  </f:entry-->
-  <f:entry name="display" title="${%Display}" field="display">
-    <select name="portlet.display">
-      <j:choose>
-         <j:when test="${instance.getDisplayStatus().compareTo('All')==0}"><option value="ALL" selected="true">${%All tests}</option></j:when>
-         <j:otherwise><option value="ALL">${%All tests}</option></j:otherwise>
-		</j:choose>
-	  	<j:choose>
-         <j:when test="${instance.getDisplayStatus().compareTo('Success')==0}"><option value="SUCCESS" selected="true">${%Only successful tests}</option></j:when>
-         <j:otherwise><option value="SUCCESS">${%Only successful tests}</option></j:otherwise>
-		</j:choose>
-		<j:choose>
-         <j:when test="${instance.getDisplayStatus().compareTo('Failed')==0}"><option value="FAILED" selected="true">${%Only failed tests}</option></j:when>
-         <j:otherwise><option value="FAILED">${%Only failed tests}</option></j:otherwise>
-		</j:choose>
-		<j:choose>
-         <j:when test="${instance.getDisplayStatus().compareTo('Skipped')==0}"><option value="SKIPPED" selected="true">${%Only skipped tests}</option></j:when>
-         <j:otherwise><option value="SKIPPED">${%Only skipped tests}</option></j:otherwise>
-		</j:choose>
-    </select>
+  <f:entry title="Display" field="displayStatus">
+     <f:select default="${descriptor.defaultDisplayStatus}"/>
   </f:entry>
   <!--<f:optionalBlock name="dynamic" title="Specify a date range">-->
     <f:entry title="${%Number of latest days to display}">

--- a/src/test/java/hudson/plugins/view/dashboard/ConfigurationAsCodeTest.java
+++ b/src/test/java/hudson/plugins/view/dashboard/ConfigurationAsCodeTest.java
@@ -1,0 +1,92 @@
+package hudson.plugins.view.dashboard;
+
+import hudson.plugins.view.dashboard.builds.LatestBuilds;
+import hudson.plugins.view.dashboard.core.HudsonStdJobsPortlet;
+import hudson.plugins.view.dashboard.core.IframePortlet;
+import hudson.plugins.view.dashboard.core.ImagePortlet;
+import hudson.plugins.view.dashboard.core.JobsPortlet;
+import hudson.plugins.view.dashboard.core.UnstableJobsPortlet;
+import hudson.plugins.view.dashboard.stats.StatBuilds;
+import hudson.plugins.view.dashboard.stats.StatJobs;
+import hudson.plugins.view.dashboard.stats.StatSlaves;
+import hudson.plugins.view.dashboard.test.TestStatisticsChart;
+import hudson.plugins.view.dashboard.test.TestStatisticsPortlet;
+import hudson.plugins.view.dashboard.test.TestTrendChart;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.Util;
+import io.jenkins.plugins.casc.model.CNode;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ConfigurationAsCodeTest {
+
+  @ClassRule
+  @ConfiguredWithCode("casc.yml")
+  public static JenkinsConfiguredWithCodeRule rule = new JenkinsConfiguredWithCodeRule();
+
+  @Test
+  public void testImportConfiguration() {
+    Dashboard.DescriptorImpl descriptor = rule.jenkins.getDescriptorByType(Dashboard.DescriptorImpl.class);
+    assertThat(descriptor, notNullValue());
+
+    Dashboard dashboard = (Dashboard) rule.jenkins.getView("test");
+    assertThat(dashboard.getViewName(), is("test"));
+
+    assertThat(dashboard.isRecurse(), is(true));
+    assertThat(dashboard.isUseCssStyle(), is(true));
+    assertThat(dashboard.isIncludeStdJobList(), is(true));
+    assertThat(dashboard.isHideJenkinsPanels(), is(true));
+    assertThat(dashboard.getIncludeRegex(), is(".*"));
+    assertThat(dashboard.getLeftPortletWidth(), is("50%"));
+    assertThat(dashboard.getRightPortletWidth(), is("50%"));
+
+    List<DashboardPortlet> topPortlets = dashboard.getTopPortlets();
+    List<DashboardPortlet> leftPortlets = dashboard.getLeftPortlets();
+    List<DashboardPortlet> rightPortlets = dashboard.getRightPortlets();
+    List<DashboardPortlet> bottomPortlets = dashboard.getBottomPortlets();
+
+    assertThat(topPortlets.size(), is(3));
+    assertThat(leftPortlets.size(), is(2));
+    assertThat(rightPortlets.size(), is(4));
+    assertThat(bottomPortlets.size(), is(3));
+
+    assertThat(topPortlets.get(0), instanceOf(StatSlaves.class));
+    assertThat(topPortlets.get(1), instanceOf(StatBuilds.class));
+    assertThat(topPortlets.get(2), instanceOf(LatestBuilds.class));
+
+    assertThat(leftPortlets.get(0), instanceOf(IframePortlet.class));
+    assertThat(leftPortlets.get(1), instanceOf(ImagePortlet.class));
+
+    assertThat(rightPortlets.get(0), instanceOf(HudsonStdJobsPortlet.class));
+    assertThat(rightPortlets.get(1), instanceOf(StatJobs.class));
+    assertThat(rightPortlets.get(2), instanceOf(JobsPortlet.class));
+    assertThat(rightPortlets.get(3), instanceOf(UnstableJobsPortlet.class));
+
+    assertThat(bottomPortlets.get(0), instanceOf(TestStatisticsChart.class));
+    assertThat(bottomPortlets.get(1), instanceOf(TestStatisticsPortlet.class));
+    assertThat(bottomPortlets.get(2), instanceOf(TestTrendChart.class));
+  }
+
+  @Test
+  public void testExportConfiguration() throws Exception {
+    final ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+    final ConfigurationContext context = new ConfigurationContext(registry);
+    CNode node = getJenkinsRoot(context).get("views").asSequence().get(0).asMapping();
+
+    final String exported = Util.toYamlString(node);
+    final String expected = Util.toStringFromYamlFile(this, "casc-export.yml");
+
+    assertThat(exported, is(expected));
+  }
+}

--- a/src/test/java/hudson/plugins/view/dashboard/test/TestTrendChartTest.java
+++ b/src/test/java/hudson/plugins/view/dashboard/test/TestTrendChartTest.java
@@ -1,19 +1,9 @@
 package hudson.plugins.view.dashboard.test;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
 import hudson.maven.MavenModuleSet;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.plugins.view.dashboard.Dashboard;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 import org.hamcrest.Matchers;
 import org.joda.time.LocalDate;
 import org.junit.Rule;
@@ -25,6 +15,17 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class TestTrendChartTest {
 
@@ -48,7 +49,7 @@ public class TestTrendChartTest {
     j.assertBuildStatus(Result.UNSTABLE, project.scheduleBuild2(0).get());
 
     when(dashboard.getJobs()).thenReturn(Collections.singletonList((Job) project));
-    TestTrendChart chart = new TestTrendChart("tests", 320, 240, "ALL", 30, 0);
+    TestTrendChart chart = new TestTrendChart("tests", 320, 240, TestTrendChart.DisplayStatus.ALL, 30, 0);
     chart = spy(chart);
     doReturn(dashboard).when(chart).getDashboard();
 

--- a/src/test/resources/hudson/plugins/view/dashboard/casc-export.yml
+++ b/src/test/resources/hudson/plugins/view/dashboard/casc-export.yml
@@ -1,0 +1,61 @@
+dashboard:
+  bottomPortlets:
+  - testStatisticsChart:
+      name: "Test Statistics Chart"
+  - testStatisticsPortlet:
+      failureColor: "E86850"
+      hideZeroTestProjects: false
+      name: "Test Statistics Grid"
+      skippedColor: "FDB813"
+      successColor: "71E66D"
+      useBackgroundColors: false
+  - testTrendChart:
+      dateRange: 0
+      dateShift: 0
+      displayStatus: ALL
+      graphHeight: 220
+      graphWidth: 300
+      name: "Test Trend Chart"
+  columns:
+  - "status"
+  - "weather"
+  - "jobName"
+  - "lastSuccess"
+  - "lastFailure"
+  - "lastDuration"
+  - "buildButton"
+  hideJenkinsPanels: true
+  includeRegex: ".*"
+  includeStdJobList: true
+  leftPortlets:
+  - iframePortlet:
+      divStyle: "width:100%;height:1000px;"
+      iframeSource: "test"
+      name: "Iframe Portlet"
+  - imagePortlet:
+      name: "Image"
+      url: "test"
+  name: "test"
+  recurse: true
+  rightPortlets:
+  - hudsonStdJobsPortlet:
+      name: "Jenkins jobs list"
+  - statJobs:
+      name: "Job statistics"
+  - jobsPortlet:
+      columnCount: 3
+      fillColumnFirst: false
+      name: "Jobs Grid"
+  - unstableJobsPortlet:
+      name: "Unstable Jobs"
+      recurse: false
+      showOnlyFailedJobs: false
+  topPortlets:
+  - statSlaves:
+      name: "Agent statistics"
+  - statBuilds:
+      name: "Build statistics"
+  - latestBuilds:
+      name: "Latest builds"
+      numBuilds: 10
+  useCssStyle: true

--- a/src/test/resources/hudson/plugins/view/dashboard/casc.yml
+++ b/src/test/resources/hudson/plugins/view/dashboard/casc.yml
@@ -1,0 +1,66 @@
+---
+jenkins:
+  views:
+    - dashboard:
+        name: "test"
+        columns:
+          - "status"
+          - "weather"
+          - "jobName"
+          - "lastSuccess"
+          - "lastFailure"
+          - "lastDuration"
+          - "buildButton"
+        recurse: true
+        includeRegex: ".*"
+        includeStdJobList: true
+        hideJenkinsPanels: true
+        useCssStyle: true
+        leftPortletWidth: "50%"
+        rightPortletWidth: "50%"
+        topPortlets:
+          - statSlaves:
+              name: "Agent statistics"
+          - statBuilds:
+              name: "Build statistics"
+          - latestBuilds:
+              name: "Latest builds"
+              numBuilds: 10
+        leftPortlets:
+          - iframePortlet:
+              divStyle: "width:100%;height:1000px;"
+              iframeSource: "test"
+              name: "Iframe Portlet"
+          - imagePortlet:
+              name: "Image"
+              url: "test"
+        rightPortlets:
+          - hudsonStdJobsPortlet:
+              name: "Jenkins jobs list"
+          - statJobs:
+              name: "Job statistics"
+          - jobsPortlet:
+              columnCount: 3
+              fillColumnFirst: false
+              name: "Jobs Grid"
+          - unstableJobsPortlet:
+              name: "Unstable Jobs"
+              recurse: false
+              showOnlyFailedJobs: false
+        bottomPortlets:
+          - testStatisticsChart:
+              name: "Test Statistics Chart"
+          - testStatisticsPortlet:
+              failureColor: "E86850"
+              hideZeroTestProjects: false
+              name: "Test Statistics Grid"
+              skippedColor: "FDB813"
+              successColor: "71E66D"
+              useBackgroundColors: false
+          - testTrendChart:
+              dateRange: 0
+              dateShift: 0
+              displayStatus: ALL
+              graphHeight: 220
+              graphWidth: 300
+              name: "Test Trend Chart"


### PR DESCRIPTION
Adds full [JCasC](https://github.com/jenkinsci/configuration-as-code-plugin) support for this plugin and all default dashboard portlets with their respective settings.

JIRA: https://issues.jenkins-ci.org/browse/JENKINS-56527
Tracking: jenkinsci/configuration-as-code-plugin#809