### PR TITLE
Bump dependency versions to fix flaky tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.12</version>
+    <version>4.13</version>
     <relativePath />
   </parent>
 
@@ -55,6 +55,11 @@
         <artifactId>commons-net</artifactId>
         <version>3.6</version>
       </dependency>
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>3.1.12</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -83,7 +88,7 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>3.2</version>
+      <version>3.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR aims to fix the following flaky tests:

`hudson.plugins.view.dashboard.test.TestSummaryForMavenJobs.summaryIncludesMavenJob`
`hudson.plugins.view.dashboard.test.TestTrendChartTest.summaryIncludesMavenJob`

They are sometimes failing to connect to maven central. Bumping this version may do the trick.

**Note:** this includes the changes on https://github.com/jenkinsci/dashboard-view-plugin/pull/83

<details>
<summary>Test error trace</summary>

````
java.lang.AssertionError: 
unexpected build status; build log was:
------
Legacy code started this job.  No cause information is available
Running as SYSTEM
Building in workspace /pct/tmp/work/dashboard-view/target/tmp/j h4982626874864003998/workspace/maven
Deleting existing workspace /pct/tmp/work/dashboard-view/target/tmp/j h4982626874864003998/workspace/maven
Staging file:/pct/tmp/work/dashboard-view/target/test-classes/hudson/plugins/view/dashboard/test/maven-unit-failure.zip
Parsing POMs
Discovered a new module xxx.testfail:testfail testfail
Modules changed, recalculating dependency graph
Established TCP socket on 45779
[maven] $ /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -cp /root/.m2/repository/org/jenkins-ci/main/maven/maven3-agent/1.13/maven3-agent-1.13.jar:/pct/tmp/work/dashboard-view/target/apache-maven-3.0.1/boot/plexus-classworlds-2.4.jar org.jvnet.hudson.maven3.agent.Maven3Main /pct/tmp/work/dashboard-view/target/apache-maven-3.0.1 /root/.m2/repository/org/jenkins-ci/main/remoting/4.3/remoting-4.3.jar /root/.m2/repository/org/jenkins-ci/main/maven/maven3-interceptor/1.13/maven3-interceptor-1.13.jar /root/.m2/repository/org/jenkins-ci/main/maven/maven3-interceptor-commons/1.13/maven3-interceptor-commons-1.13.jar 45779
Picked up JAVA_TOOL_OPTIONS: -Xmx1g
<===[JENKINS REMOTING CAPACITY]===>&amp#0;&amp#0;&amp#0;channel started
Executing Maven:  -B -f /pct/tmp/work/dashboard-view/target/tmp/j h4982626874864003998/workspace/maven/pom.xml test
[INFO] Scanning for projects...
[INFO] 
[INFO] &amp#27;[1m-----------------------< &amp#27;[0;36mxxx.testfail:testfail&amp#27;[0;1m >------------------------&amp#27;[m
[INFO] &amp#27;[1mBuilding testfail 1.0-SNAPSHOT&amp#27;[m
[INFO] &amp#27;[1m--------------------------------[ jar ]---------------------------------&amp#27;[m
Downloading: http://repo1.maven.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.4.3/maven-resources-plugin-2.4.3.jar
[INFO] &amp#27;[1m------------------------------------------------------------------------&amp#27;[m
[INFO] &amp#27;[1;31mBUILD FAILURE&amp#27;[m
[INFO] &amp#27;[1m------------------------------------------------------------------------&amp#27;[m
[INFO] Total time: 0.894 s
[INFO] Finished at: 2020-08-11T07:34:14Z
[INFO] &amp#27;[1m------------------------------------------------------------------------&amp#27;[m
Waiting for Jenkins to finish collecting data
[ERROR] Plugin org.apache.maven.plugins:maven-resources-plugin:2.4.3 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:jar:2.4.3 from/to central (http://repo1.maven.org/maven2): Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.4.3/maven-resources-plugin-2.4.3.jar -> [Help 1]
[ERROR] 
[JENKINS] Archiving /pct/tmp/work/dashboard-view/target/tmp/j h4982626874864003998/workspace/maven/pom.xml to xxx.testfail/testfail/1.0-SNAPSHOT/testfail-1.0-SNAPSHOT.pom
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
channel stopped
Finished: FAILURE

------

Expected: is <UNSTABLE>
     but: was <FAILURE>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.jvnet.hudson.test.JenkinsRule.assertBuildStatus(JenkinsRule.java:1335)
	at hudson.plugins.view.dashboard.test.TestSummaryForMavenJobs.summaryIncludesMavenJob(TestSummaryForMavenJobs.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:600)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```
</details>