### PR TITLE
Removing `jenkins` overrides in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 #!groovy
-def recentLTS = '2.277.4'
 buildPlugin(configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
-  [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
+  [ platform: "linux", jdk: "8" ],
+  [ platform: "windows", jdk: "8", javaLevel: "8" ],
+  [ platform: "linux", jdk: "11", javaLevel: "8" ],
 ])


### PR DESCRIPTION
#102 updated the `jenkins.version` to a reasonably recent line, so rather than e4879e56f25e465ea91a3c92107c47670fcebe59 we can just have CI test against the specified baseline.
