### PR TITLE
Switch from fmt to spotless

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/README.md
+++ b/README.md
@@ -138,16 +138,16 @@ local changes before commiting.
 ### Code Style
 
 This plugin tries to migrate to [Google Java Code Style], please try to adhere
-to that style whenever adding new files or making big changes to existing
-files. If your IDE doesn't support this style, you can use the
-[fmt-maven-plugin], like this:
+to that style whenever adding new files or making changes to existing files.
+The style is enforced using the [spotless] plugin, if the build fails because
+you were using the "wrong" style, you can fix it by running:
 
-    $ mvn fmt:format -DfilesNamePattern=ChangedFile\.java
+    $ mvn spotless:apply
 
 to reformat Java code in the proper style.
 
 [Google Java Code Style]: https://google.github.io/styleguide/javaguide.html
-[fmt-maven-plugin]: https://github.com/coveo/fmt-maven-plugin
+[spotless]: https://github.com/diffplug/spotless
 
 ## Extending the Dashboard View plugin
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
   <packaging>hpi</packaging>
 
   <name>Dashboard View</name>
-  <description>Jenkins view that shows various cuts of build information via configured portlets.</description>
+  <description>Jenkins view that shows various cuts of build information via configured portlets.
+  </description>
   <url>https://github.com/jenkinsci/dashboard-view-plugin</url>
   <licenses>
     <license>
@@ -139,16 +140,29 @@
   </pluginRepositories>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.coveo</groupId>
-          <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.9.1</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.17.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <!-- get better with time -->
+          <ratchetFrom>origin/master</ratchetFrom>
+          <java>
+            <endWithNewline/>
+            <importOrder/>
+            <removeUnusedImports/>
+            <googleJavaFormat/>
+          </java>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Using spotless instead of the fmt-maven-plugin:
- No hard dependency on Java 11
- Automatic checking/fixing of changed files (ratchet)
- Possible to add other formatters later

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
