### PR TITLE
Increase Jenkins baseline to 2.289.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 #!groovy
+def recentLTS = '2.332.1'
 buildPlugin(configurations: [
-  [ platform: "linux", jdk: "8" ],
-  [ platform: "windows", jdk: "8", javaLevel: "8" ],
-  [ platform: "linux", jdk: "11", javaLevel: "8" ],
+  [ platform: 'linux', jdk: '8', jenkins: null ],
+  [ platform: 'windows', jdk: '11', jenkins: recentLTS ],
+  [ platform: 'linux', jdk: '11', jenkins: recentLTS ],
+  // Test with Java 17
+  [ platform: 'linux', jdk: '17', jenkins: '2.342' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.29</version>
+    <version>4.40</version>
     <relativePath />
   </parent>
 
@@ -44,8 +44,7 @@
     <revision>2</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.277.1</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.289.3</jenkins.version>
   </properties>
 
   <!-- For RequireUpperBoundDeps -->
@@ -53,8 +52,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.277.x</artifactId>
-        <version>961.vf0c9f6f59827</version>
+        <artifactId>bom-2.289.x</artifactId>
+        <version>1246.va_b_50630c1d19</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -79,8 +78,14 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>3.10</version>
+      <version>3.16</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>symbol-annotation</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Additionally, this enables testing against Java 17
