### PR TITLE
Make spotless less annoying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,11 @@
             <endWithNewline />
             <importOrder />
             <removeUnusedImports />
-            <googleJavaFormat />
+            <googleJavaFormat>
+              <!-- Last version that supports Java 8, the plugin does handle this internally
+              but it will give different versions based off of the JVM version, not good for CI -->
+              <version>1.7</version>
+            </googleJavaFormat>
           </java>
           <pom>
             <sortPom>

--- a/pom.xml
+++ b/pom.xml
@@ -135,13 +135,6 @@
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>2.22.8</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <!-- get better with time -->
           <ratchetFrom>origin/master</ratchetFrom>
@@ -152,6 +145,14 @@
             <googleJavaFormat />
           </java>
         </configuration>
+        <!-- executions> Disabled for now, since ratchet doesn't work in CI
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions -->
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,13 @@
   <packaging>hpi</packaging>
 
   <name>Dashboard View</name>
-  <description>Jenkins view that shows various cuts of build information via configured portlets.
-  </description>
+  <description>Jenkins view that shows various cuts of build information via configured portlets.</description>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>
-      <distribution>repo</distribution>
       <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
     </license>
   </licenses>
 
@@ -36,8 +35,8 @@
   <scm>
     <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <properties>
@@ -54,8 +53,8 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.289.x</artifactId>
         <version>1438.v6a_2c29d73f82</version>
-        <scope>import</scope>
         <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>commons-net</groupId>
@@ -115,7 +114,6 @@
     </dependency>
   </dependencies>
 
-
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
@@ -144,6 +142,12 @@
             <removeUnusedImports />
             <googleJavaFormat />
           </java>
+          <pom>
+            <sortPom>
+              <expandEmptyElements>false</expandEmptyElements>
+              <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+            </sortPom>
+          </pom>
         </configuration>
         <!-- executions> Disabled for now, since ratchet doesn't work in CI
           <execution>


### PR DESCRIPTION
Running spotless automatically and failing the build based on its result does more harm then good: It annoys contributors - So we disable it for now, but also apply some better configuration