### PR TITLE
Use upstream Spotless configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.54</version>
+    <version>4.59</version>
     <relativePath />
   </parent>
 
@@ -16,6 +16,7 @@
   <name>Dashboard View</name>
   <description>Jenkins view that shows various cuts of build information via configured portlets.</description>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+
   <licenses>
     <license>
       <name>MIT License</name>
@@ -70,6 +71,22 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness-tools</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
       <version>3.16</version>
@@ -87,37 +104,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness-tools</artifactId>
-      <version>2.2</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci.main</groupId>
-          <artifactId>jenkins-test-harness</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.configuration-as-code</groupId>
-      <artifactId>test-harness</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci.main</groupId>
-          <artifactId>jenkins-test-harness</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 
@@ -136,35 +125,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.30.0</version>
-        <configuration>
-          <!-- get better with time -->
-          <ratchetFrom>origin/main</ratchetFrom>
-          <java>
-            <endWithNewline />
-            <importOrder />
-            <removeUnusedImports />
-            <googleJavaFormat />
-          </java>
-          <pom>
-            <sortPom>
-              <expandEmptyElements>false</expandEmptyElements>
-              <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-            </sortPom>
-          </pom>
-        </configuration>
-        <!-- executions> Disabled for now, since ratchet doesn't work in CI
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>validate</phase>
-          </execution>
-        </executions -->
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/hudson/plugins/view/dashboard/Dashboard.java
+++ b/src/main/java/hudson/plugins/view/dashboard/Dashboard.java
@@ -31,222 +31,223 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 public class Dashboard extends ListView {
 
-  /** Use custom CSS style provided by the user */
-  private boolean useCssStyle = false;
-  /** Show standard jobs list at the top of the page */
-  private boolean includeStdJobList = false;
-  /** Hide standard Jenkins panels (full screen view) */
-  private boolean hideJenkinsPanels = false;
-  /** The width of the left portlets */
-  private String leftPortletWidth = "50%";
-  /** The width of the right portlets */
-  private String rightPortletWidth = "50%";
+    /** Use custom CSS style provided by the user */
+    private boolean useCssStyle = false;
+    /** Show standard jobs list at the top of the page */
+    private boolean includeStdJobList = false;
+    /** Hide standard Jenkins panels (full screen view) */
+    private boolean hideJenkinsPanels = false;
+    /** The width of the left portlets */
+    private String leftPortletWidth = "50%";
+    /** The width of the right portlets */
+    private String rightPortletWidth = "50%";
 
-  private List<DashboardPortlet> leftPortlets = new ArrayList<>();
-  private List<DashboardPortlet> rightPortlets = new ArrayList<>();
-  private List<DashboardPortlet> topPortlets = new ArrayList<>();
-  private List<DashboardPortlet> bottomPortlets = new ArrayList<>();
+    private List<DashboardPortlet> leftPortlets = new ArrayList<>();
+    private List<DashboardPortlet> rightPortlets = new ArrayList<>();
+    private List<DashboardPortlet> topPortlets = new ArrayList<>();
+    private List<DashboardPortlet> bottomPortlets = new ArrayList<>();
 
-  @DataBoundConstructor
-  public Dashboard(String name) {
-    super(name);
-  }
-
-  public boolean isUseCssStyle() {
-    return useCssStyle;
-  }
-
-  public boolean isIncludeStdJobList() {
-    return includeStdJobList;
-  }
-
-  /** @since 2.13 */
-  @DataBoundSetter
-  public void setIncludeStdJobList(boolean includeStdJobList) {
-    this.includeStdJobList = includeStdJobList;
-  }
-
-  public boolean isHideJenkinsPanels() {
-    return hideJenkinsPanels;
-  }
-
-  @StaplerDispatchable
-  public List<DashboardPortlet> getLeftPortlets() {
-    return leftPortlets;
-  }
-
-  @StaplerDispatchable
-  public List<DashboardPortlet> getRightPortlets() {
-    return rightPortlets;
-  }
-
-  @StaplerDispatchable
-  public List<DashboardPortlet> getTopPortlets() {
-    return topPortlets;
-  }
-
-  @StaplerDispatchable
-  public List<DashboardPortlet> getBottomPortlets() {
-    return bottomPortlets;
-  }
-
-  public synchronized String getLeftPortletWidth() {
-    return leftPortletWidth;
-  }
-
-  public synchronized String getRightPortletWidth() {
-    return rightPortletWidth;
-  }
-
-  @DataBoundSetter
-  public synchronized void setUseCssStyle(boolean useCssStyle) {
-    this.useCssStyle = useCssStyle;
-  }
-
-  @DataBoundSetter
-  public void setHideJenkinsPanels(boolean hideJenkinsPanels) {
-    this.hideJenkinsPanels = hideJenkinsPanels;
-  }
-
-  @DataBoundSetter
-  public synchronized void setLeftPortletWidth(String leftPortletWidth) {
-    this.leftPortletWidth = leftPortletWidth;
-  }
-
-  @DataBoundSetter
-  public synchronized void setRightPortletWidth(String rightPortletWidth) {
-    this.rightPortletWidth = rightPortletWidth;
-  }
-
-  @DataBoundSetter
-  public void setLeftPortlets(List<DashboardPortlet> leftPortlets) {
-    this.leftPortlets = leftPortlets;
-  }
-
-  @DataBoundSetter
-  public void setRightPortlets(List<DashboardPortlet> rightPortlets) {
-    this.rightPortlets = rightPortlets;
-  }
-
-  @DataBoundSetter
-  public void setTopPortlets(List<DashboardPortlet> topPortlets) {
-    this.topPortlets = topPortlets;
-  }
-
-  @DataBoundSetter
-  public void setBottomPortlets(List<DashboardPortlet> bottomPortlets) {
-    this.bottomPortlets = bottomPortlets;
-  }
-
-  public String getPortletUrl(DashboardPortlet portlet) {
-    int pos = topPortlets.indexOf(portlet);
-    if (pos > -1) return "topPortlets/" + pos;
-    pos = leftPortlets.indexOf(portlet);
-    if (pos > -1) return "leftPortlets/" + pos;
-    pos = rightPortlets.indexOf(portlet);
-    if (pos > -1) return "rightPortlets/" + pos;
-    pos = bottomPortlets.indexOf(portlet);
-    if (pos > -1) return "bottomPortlets/" + pos;
-    return "";
-  }
-
-  @Deprecated
-  public DescriptorExtensionList<DashboardPortlet, Descriptor<DashboardPortlet>>
-      getDashboardPortletDescriptors() {
-    return DashboardPortlet.all();
-  }
-
-  public List<Descriptor<DashboardPortlet>> getSortedDashboardPortletDescriptors() {
-    DescriptorExtensionList<DashboardPortlet, Descriptor<DashboardPortlet>> list =
-        DashboardPortlet.all();
-    List<Descriptor<DashboardPortlet>> descriptors = new ArrayList<>(list);
-
-    descriptors.sort(Comparator.comparing(Descriptor::getDisplayName));
-
-    return descriptors;
-  }
-
-  /* Use contains */
-  @Deprecated
-  @SuppressFBWarnings(
-      value = "NM_METHOD_NAMING_CONVENTION",
-      justification = "backwards compatibility, but seems unused internally.")
-  @Restricted(DoNotUse.class)
-  public synchronized boolean HasItem(TopLevelItem item) {
-    List<TopLevelItem> items = getItems();
-    return items.contains(item);
-  }
-
-  /* Use getItems */
-  public synchronized List<Job> getJobs() {
-    List<Job> jobs = new ArrayList<>();
-
-    for (TopLevelItem item : getItems()) {
-      if (item instanceof Job) {
-        jobs.add((Job) item);
-      }
+    @DataBoundConstructor
+    public Dashboard(String name) {
+        super(name);
     }
 
-    return jobs;
-  }
-
-  @Override
-  protected synchronized void submit(StaplerRequest req)
-      throws IOException, ServletException, FormException {
-    super.submit(req);
-
-    try {
-      req.setCharacterEncoding("UTF-8");
-    } catch (UnsupportedEncodingException ex) {
-      DashboardLog.error("Dashboard", ex.getLocalizedMessage());
-    }
-    JSONObject json = req.getSubmittedForm();
-
-    String sIncludeStdJobList = Util.nullify(req.getParameter("includeStdJobList"));
-    includeStdJobList = sIncludeStdJobList != null && "on".equals(sIncludeStdJobList);
-
-    String shideJenkinsPanels = Util.nullify(req.getParameter("hideJenkinsPanels"));
-    hideJenkinsPanels = shideJenkinsPanels != null && "on".equals(shideJenkinsPanels);
-
-    String sUseCssStyle = Util.nullify(req.getParameter("useCssStyle"));
-    useCssStyle = sUseCssStyle != null && "on".equals(sUseCssStyle);
-
-    if (useCssStyle) {
-      if (req.getParameter("leftPortletWidth") != null) {
-        leftPortletWidth = req.getParameter("leftPortletWidth");
-      }
-
-      if (req.getParameter("rightPortletWidth") != null) {
-        rightPortletWidth = req.getParameter("rightPortletWidth");
-      }
-    } else {
-      leftPortletWidth = rightPortletWidth = "50%";
+    public boolean isUseCssStyle() {
+        return useCssStyle;
     }
 
-    topPortlets =
-        Descriptor.newInstancesFromHeteroList(req, json, "topPortlet", DashboardPortlet.all());
-    leftPortlets =
-        Descriptor.newInstancesFromHeteroList(req, json, "leftPortlet", DashboardPortlet.all());
-    rightPortlets =
-        Descriptor.newInstancesFromHeteroList(req, json, "rightPortlet", DashboardPortlet.all());
-    bottomPortlets =
-        Descriptor.newInstancesFromHeteroList(req, json, "bottomPortlet", DashboardPortlet.all());
-  }
+    public boolean isIncludeStdJobList() {
+        return includeStdJobList;
+    }
 
-  @Override
-  public void rename(String newName) throws FormException {
-    super.rename(newName);
-    // Bug 6689 <http://issues.jenkins-ci.org/browse/JENKINS-6689>
-    // TODO: if this view is the default view configured in Jenkins, the we must keep it after
-    // renaming
-  }
+    /** @since 2.13 */
+    @DataBoundSetter
+    public void setIncludeStdJobList(boolean includeStdJobList) {
+        this.includeStdJobList = includeStdJobList;
+    }
 
-  @Extension
-  public static final class DescriptorImpl extends ViewDescriptor {
+    public boolean isHideJenkinsPanels() {
+        return hideJenkinsPanels;
+    }
+
+    @StaplerDispatchable
+    public List<DashboardPortlet> getLeftPortlets() {
+        return leftPortlets;
+    }
+
+    @StaplerDispatchable
+    public List<DashboardPortlet> getRightPortlets() {
+        return rightPortlets;
+    }
+
+    @StaplerDispatchable
+    public List<DashboardPortlet> getTopPortlets() {
+        return topPortlets;
+    }
+
+    @StaplerDispatchable
+    public List<DashboardPortlet> getBottomPortlets() {
+        return bottomPortlets;
+    }
+
+    public synchronized String getLeftPortletWidth() {
+        return leftPortletWidth;
+    }
+
+    public synchronized String getRightPortletWidth() {
+        return rightPortletWidth;
+    }
+
+    @DataBoundSetter
+    public synchronized void setUseCssStyle(boolean useCssStyle) {
+        this.useCssStyle = useCssStyle;
+    }
+
+    @DataBoundSetter
+    public void setHideJenkinsPanels(boolean hideJenkinsPanels) {
+        this.hideJenkinsPanels = hideJenkinsPanels;
+    }
+
+    @DataBoundSetter
+    public synchronized void setLeftPortletWidth(String leftPortletWidth) {
+        this.leftPortletWidth = leftPortletWidth;
+    }
+
+    @DataBoundSetter
+    public synchronized void setRightPortletWidth(String rightPortletWidth) {
+        this.rightPortletWidth = rightPortletWidth;
+    }
+
+    @DataBoundSetter
+    public void setLeftPortlets(List<DashboardPortlet> leftPortlets) {
+        this.leftPortlets = leftPortlets;
+    }
+
+    @DataBoundSetter
+    public void setRightPortlets(List<DashboardPortlet> rightPortlets) {
+        this.rightPortlets = rightPortlets;
+    }
+
+    @DataBoundSetter
+    public void setTopPortlets(List<DashboardPortlet> topPortlets) {
+        this.topPortlets = topPortlets;
+    }
+
+    @DataBoundSetter
+    public void setBottomPortlets(List<DashboardPortlet> bottomPortlets) {
+        this.bottomPortlets = bottomPortlets;
+    }
+
+    public String getPortletUrl(DashboardPortlet portlet) {
+        int pos = topPortlets.indexOf(portlet);
+        if (pos > -1) {
+            return "topPortlets/" + pos;
+        }
+        pos = leftPortlets.indexOf(portlet);
+        if (pos > -1) {
+            return "leftPortlets/" + pos;
+        }
+        pos = rightPortlets.indexOf(portlet);
+        if (pos > -1) {
+            return "rightPortlets/" + pos;
+        }
+        pos = bottomPortlets.indexOf(portlet);
+        if (pos > -1) {
+            return "bottomPortlets/" + pos;
+        }
+        return "";
+    }
+
+    @Deprecated
+    public DescriptorExtensionList<DashboardPortlet, Descriptor<DashboardPortlet>> getDashboardPortletDescriptors() {
+        return DashboardPortlet.all();
+    }
+
+    public List<Descriptor<DashboardPortlet>> getSortedDashboardPortletDescriptors() {
+        DescriptorExtensionList<DashboardPortlet, Descriptor<DashboardPortlet>> list = DashboardPortlet.all();
+        List<Descriptor<DashboardPortlet>> descriptors = new ArrayList<>(list);
+
+        descriptors.sort(Comparator.comparing(Descriptor::getDisplayName));
+
+        return descriptors;
+    }
+
+    /* Use contains */
+    @Deprecated
+    @SuppressFBWarnings(
+            value = "NM_METHOD_NAMING_CONVENTION",
+            justification = "backwards compatibility, but seems unused internally.")
+    @Restricted(DoNotUse.class)
+    public synchronized boolean HasItem(TopLevelItem item) {
+        List<TopLevelItem> items = getItems();
+        return items.contains(item);
+    }
+
+    /* Use getItems */
+    public synchronized List<Job> getJobs() {
+        List<Job> jobs = new ArrayList<>();
+
+        for (TopLevelItem item : getItems()) {
+            if (item instanceof Job) {
+                jobs.add((Job) item);
+            }
+        }
+
+        return jobs;
+    }
 
     @Override
-    public String getDisplayName() {
-      return Messages.Dashboard_DisplayName();
+    protected synchronized void submit(StaplerRequest req) throws IOException, ServletException, FormException {
+        super.submit(req);
+
+        try {
+            req.setCharacterEncoding("UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            DashboardLog.error("Dashboard", ex.getLocalizedMessage());
+        }
+        JSONObject json = req.getSubmittedForm();
+
+        String sIncludeStdJobList = Util.nullify(req.getParameter("includeStdJobList"));
+        includeStdJobList = sIncludeStdJobList != null && "on".equals(sIncludeStdJobList);
+
+        String shideJenkinsPanels = Util.nullify(req.getParameter("hideJenkinsPanels"));
+        hideJenkinsPanels = shideJenkinsPanels != null && "on".equals(shideJenkinsPanels);
+
+        String sUseCssStyle = Util.nullify(req.getParameter("useCssStyle"));
+        useCssStyle = sUseCssStyle != null && "on".equals(sUseCssStyle);
+
+        if (useCssStyle) {
+            if (req.getParameter("leftPortletWidth") != null) {
+                leftPortletWidth = req.getParameter("leftPortletWidth");
+            }
+
+            if (req.getParameter("rightPortletWidth") != null) {
+                rightPortletWidth = req.getParameter("rightPortletWidth");
+            }
+        } else {
+            leftPortletWidth = rightPortletWidth = "50%";
+        }
+
+        topPortlets = Descriptor.newInstancesFromHeteroList(req, json, "topPortlet", DashboardPortlet.all());
+        leftPortlets = Descriptor.newInstancesFromHeteroList(req, json, "leftPortlet", DashboardPortlet.all());
+        rightPortlets = Descriptor.newInstancesFromHeteroList(req, json, "rightPortlet", DashboardPortlet.all());
+        bottomPortlets = Descriptor.newInstancesFromHeteroList(req, json, "bottomPortlet", DashboardPortlet.all());
     }
-  }
+
+    @Override
+    public void rename(String newName) throws FormException {
+        super.rename(newName);
+        // Bug 6689 <http://issues.jenkins-ci.org/browse/JENKINS-6689>
+        // TODO: if this view is the default view configured in Jenkins, the we must keep it after
+        // renaming
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends ViewDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_DisplayName();
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/DashboardLog.java
+++ b/src/main/java/hudson/plugins/view/dashboard/DashboardLog.java
@@ -8,27 +8,26 @@ import java.util.logging.Logger;
  * @author Marco Ambu
  */
 public class DashboardLog {
-   
-   private static String loggerName = "DashboardView";
-   
-   public static void debug(String component, String msg) {
-      Logger l = Logger.getLogger(loggerName);
-      l.log(Level.FINEST, "[" + component + "] " + msg);
-   }
-   
-   public static void info(String component, String msg) {
-      Logger l = Logger.getLogger(loggerName);
-      l.log(Level.INFO, "[" + component + "] " + msg);
-   }
-   
-   public static void warning(String component, String msg) {
-      Logger l = Logger.getLogger(loggerName);
-      l.log(Level.WARNING, "[" + component + "] " + msg);
-   }
-   
-   public static void error(String component, String msg) {
-      Logger l = Logger.getLogger(loggerName);
-      l.log(Level.SEVERE, "[" + component + "] " + msg);
-   }
 
+    private static String loggerName = "DashboardView";
+
+    public static void debug(String component, String msg) {
+        Logger l = Logger.getLogger(loggerName);
+        l.log(Level.FINEST, "[" + component + "] " + msg);
+    }
+
+    public static void info(String component, String msg) {
+        Logger l = Logger.getLogger(loggerName);
+        l.log(Level.INFO, "[" + component + "] " + msg);
+    }
+
+    public static void warning(String component, String msg) {
+        Logger l = Logger.getLogger(loggerName);
+        l.log(Level.WARNING, "[" + component + "] " + msg);
+    }
+
+    public static void error(String component, String msg) {
+        Logger l = Logger.getLogger(loggerName);
+        l.log(Level.SEVERE, "[" + component + "] " + msg);
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/DashboardPortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/DashboardPortlet.java
@@ -16,52 +16,53 @@ import org.kohsuke.stapler.StaplerRequest;
  *
  * @author Peter Hayes
  */
-public abstract class DashboardPortlet
-    implements ModelObject, Describable<DashboardPortlet>, ExtensionPoint {
+public abstract class DashboardPortlet implements ModelObject, Describable<DashboardPortlet>, ExtensionPoint {
 
-  private final String name;
+    private final String name;
 
-  public DashboardPortlet(String name) {
-    this.name = name;
-  }
+    public DashboardPortlet(String name) {
+        this.name = name;
+    }
 
-  public String getId() {
-    return "portlet-" + getDashboard().getPortletUrl(this).replace('/', '-');
-  }
+    public String getId() {
+        return "portlet-" + getDashboard().getPortletUrl(this).replace('/', '-');
+    }
 
-  public String getName() {
-    return name;
-  }
+    public String getName() {
+        return name;
+    }
 
-  public Dashboard getDashboard() {
-    // TODO Can the dashboard instance be a field on this class -- parent?
-    StaplerRequest req = Stapler.getCurrentRequest();
-    return req != null ? req.findAncestorObject(Dashboard.class) : null;
-  }
+    public Dashboard getDashboard() {
+        // TODO Can the dashboard instance be a field on this class -- parent?
+        StaplerRequest req = Stapler.getCurrentRequest();
+        return req != null ? req.findAncestorObject(Dashboard.class) : null;
+    }
 
-  public String getDisplayName() {
-    return getName();
-  }
+    @Override
+    public String getDisplayName() {
+        return getName();
+    }
 
-  public String getUrl() {
-    return getDashboard().getPortletUrl(this) + '/';
-  }
+    public String getUrl() {
+        return getDashboard().getPortletUrl(this) + '/';
+    }
 
-  /** Support accessing jobs available via view through portlets */
-  public TopLevelItem getJob(String name) {
-    return getDashboard().getJob(name);
-  }
+    /** Support accessing jobs available via view through portlets */
+    public TopLevelItem getJob(String name) {
+        return getDashboard().getJob(name);
+    }
 
-  public Descriptor<DashboardPortlet> getDescriptor() {
-    return (Descriptor<DashboardPortlet>) Jenkins.get().getDescriptor(getClass());
-  }
+    @Override
+    public Descriptor<DashboardPortlet> getDescriptor() {
+        return (Descriptor<DashboardPortlet>) Jenkins.get().getDescriptor(getClass());
+    }
 
-  /** Returns all the registered {@link DashboardPortlet} descriptors. */
-  public static DescriptorExtensionList<DashboardPortlet, Descriptor<DashboardPortlet>> all() {
-    return Jenkins.get().getDescriptorList(DashboardPortlet.class);
-  }
+    /** Returns all the registered {@link DashboardPortlet} descriptors. */
+    public static DescriptorExtensionList<DashboardPortlet, Descriptor<DashboardPortlet>> all() {
+        return Jenkins.get().getDescriptorList(DashboardPortlet.class);
+    }
 
-  public static Comparator getComparator() {
-    return (Comparator<Dashboard>) (p1, p2) -> p1.getDescription().compareTo(p2.getDescription());
-  }
+    public static Comparator getComparator() {
+        return (Comparator<Dashboard>) (p1, p2) -> p1.getDescription().compareTo(p2.getDescription());
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/builds/LatestBuilds.java
+++ b/src/main/java/hudson/plugins/view/dashboard/builds/LatestBuilds.java
@@ -5,47 +5,45 @@ import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.plugins.view.dashboard.DashboardPortlet;
+import hudson.plugins.view.dashboard.Messages;
 import java.text.DateFormat;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-
-import hudson.plugins.view.dashboard.Messages;
 import java.util.PriorityQueue;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 public class LatestBuilds extends DashboardPortlet {
 
-   /**
-    * Number of latest builds which will be displayed on the screen
-    */
-   private int numBuilds = 10;
+    /**
+     * Number of latest builds which will be displayed on the screen
+     */
+    private int numBuilds = 10;
 
-   @DataBoundConstructor
-   public LatestBuilds(String name, int numBuilds) {
-      super(name);
-      this.numBuilds = numBuilds;
-   }
+    @DataBoundConstructor
+    public LatestBuilds(String name, int numBuilds) {
+        super(name);
+        this.numBuilds = numBuilds;
+    }
 
-   public int getNumBuilds() {
-      return numBuilds <= 0 ? 10 : numBuilds;
-   }
+    public int getNumBuilds() {
+        return numBuilds <= 0 ? 10 : numBuilds;
+    }
 
-   public String getTimestampSortData(Run run) {
-      return String.valueOf(run.getTimeInMillis());
-   }
+    public String getTimestampSortData(Run run) {
+        return String.valueOf(run.getTimeInMillis());
+    }
 
-   public String getTimestampString(Run run) {
-      return DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM).format(new Date(run.getTimeInMillis()));
-   }
+    public String getTimestampString(Run run) {
+        return DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM)
+                .format(new Date(run.getTimeInMillis()));
+    }
 
-   /**
-    * Last <code>N_LATEST_BUILDS</code> builds
-    *
-    */
-   public List<Run> getFinishedBuilds() {
+    /**
+     * Last <code>N_LATEST_BUILDS</code> builds
+     *
+     */
+    public List<Run> getFinishedBuilds() {
         List<Job> jobs = getDashboardJobs();
 
         PriorityQueue<Run> queue = new PriorityQueue<>(numBuilds, Run.ORDER_BY_DATE);
@@ -70,25 +68,25 @@ public class LatestBuilds extends DashboardPortlet {
         }
 
         return recentBuilds;
-   }
+    }
 
-   /**
-    * for unit test
-    */
-   protected List<Job> getDashboardJobs() {
-       return getDashboard().getJobs();
-   }
+    /**
+     * for unit test
+     */
+    protected List<Job> getDashboardJobs() {
+        return getDashboard().getJobs();
+    }
 
-   public String getBuildColumnSortData(Run<?, ?> build) {
-      return String.valueOf(build.getNumber());
-   }
+    public String getBuildColumnSortData(Run<?, ?> build) {
+        return String.valueOf(build.getNumber());
+    }
 
-   @Extension
-   public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
 
-      @Override
-      public String getDisplayName() {
-         return Messages.Dashboard_LatestBuilds();
-      }
-   }
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_LatestBuilds();
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/core/HudsonStdJobsPortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/core/HudsonStdJobsPortlet.java
@@ -13,17 +13,17 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class HudsonStdJobsPortlet extends DashboardPortlet {
 
-   @DataBoundConstructor
-   public HudsonStdJobsPortlet(String name) {
-      super(name);
-   }
+    @DataBoundConstructor
+    public HudsonStdJobsPortlet(String name) {
+        super(name);
+    }
 
-   @Extension
-   public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
 
-      @Override
-      public String getDisplayName() {
-         return Messages.Dashboard_JenkinsJobsList();
-      }
-   }
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_JenkinsJobsList();
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/core/IframePortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/core/IframePortlet.java
@@ -18,113 +18,114 @@ import org.kohsuke.stapler.QueryParameter;
 
 public class IframePortlet extends DashboardPortlet {
 
-  private String iframeSource;
-  private String effectiveUrl;
-  private final String divStyle;
-  private static boolean DO_NOT_USE_SANDBOX =
-      SystemProperties.getBoolean(IframePortlet.class.getName() + ".doNotUseSandbox");
-  private static String SANDBOX_VALUE =
-      SystemProperties.getString(IframePortlet.class.getName() + ".sandboxAttributeValue", "");
+    private String iframeSource;
+    private String effectiveUrl;
+    private final String divStyle;
+    private static boolean DO_NOT_USE_SANDBOX =
+            SystemProperties.getBoolean(IframePortlet.class.getName() + ".doNotUseSandbox");
+    private static String SANDBOX_VALUE =
+            SystemProperties.getString(IframePortlet.class.getName() + ".sandboxAttributeValue", "");
 
-  @DataBoundConstructor
-  public IframePortlet(String name, String divStyle) {
-    super(name);
-    this.divStyle = divStyle;
-  }
-
-  public String getIframeSource() {
-    return iframeSource;
-  }
-
-  public String getEffectiveUrl() {
-    return effectiveUrl;
-  }
-
-  public String getDivStyle() {
-    return divStyle;
-  }
-
-  @DataBoundSetter
-  public void setIframeSource(String iframeSource) {
-    this.iframeSource = iframeSource;
-    this.overridePlaceholdersInUrl();
-  }
-
-  public boolean isIframeSourceValid() {
-    return getUrlError(iframeSource) == null;
-  }
-
-  public boolean isUseSandbox() {
-    return !DO_NOT_USE_SANDBOX;
-  }
-
-  public String getSandboxValue() {
-    return SANDBOX_VALUE;
-  }
-
-  private void overridePlaceholdersInUrl() {
-    if (iframeSource != null) {
-      if (getDashboard() != null) {
-        effectiveUrl = iframeSource.replaceAll("\\$\\{viewName\\}", getDashboard().getViewName());
-        effectiveUrl = effectiveUrl.replaceAll("\\$\\{jobsList\\}", jobsListAsString());
-      } else {
-        effectiveUrl = iframeSource;
-      }
-    } else {
-      effectiveUrl = null;
-    }
-  }
-
-  private String jobsListAsString() {
-    StringBuilder sb = new StringBuilder();
-    Iterator<Job> jobs = getDashboard().getJobs().iterator();
-    if (jobs.hasNext()) {
-      sb.append(jobs.next().getName());
-    }
-    while (jobs.hasNext()) {
-      sb.append(",");
-      sb.append(jobs.next().getName());
-    }
-    return sb.toString();
-  }
-
-  @Extension
-  public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
-
-    @Override
-    public String getDisplayName() {
-      return Messages.Dashboard_IframePortlet();
+    @DataBoundConstructor
+    public IframePortlet(String name, String divStyle) {
+        super(name);
+        this.divStyle = divStyle;
     }
 
-    public FormValidation doCheckIframeSource(@QueryParameter String value) {
-      String error = getUrlError(value);
-      if (error != null) {
-        return FormValidation.error(error);
-      }
-      return FormValidation.ok();
+    public String getIframeSource() {
+        return iframeSource;
     }
-  }
 
-  /**
-   * Checks if the passed string is a valid HTTP or relative URL.
-   *
-   * @return Localized error message or null if URL is valid.
-   */
-  @CheckForNull
-  protected static final String getUrlError(String url) {
-    if (StringUtils.isBlank(url)) {
-      return Messages.Dashboard_UrlEmpty();
+    public String getEffectiveUrl() {
+        return effectiveUrl;
     }
-    try {
-      final URI allowedUrl = new URI(url);
-      final String protocol = allowedUrl.getScheme();
-      if (!allowedUrl.isAbsolute() || protocol.equals("http") || protocol.equals("https")) {
-        return null;
-      } else {
-        return Messages.Dashboard_UrlHttp();
-      }
-    } catch (URISyntaxException e) {
-      return Messages.Dashboard_UrlInvalid(e.getMessage());
+
+    public String getDivStyle() {
+        return divStyle;
     }
-  }
+
+    @DataBoundSetter
+    public void setIframeSource(String iframeSource) {
+        this.iframeSource = iframeSource;
+        this.overridePlaceholdersInUrl();
+    }
+
+    public boolean isIframeSourceValid() {
+        return getUrlError(iframeSource) == null;
+    }
+
+    public boolean isUseSandbox() {
+        return !DO_NOT_USE_SANDBOX;
+    }
+
+    public String getSandboxValue() {
+        return SANDBOX_VALUE;
+    }
+
+    private void overridePlaceholdersInUrl() {
+        if (iframeSource != null) {
+            if (getDashboard() != null) {
+                effectiveUrl = iframeSource.replaceAll(
+                        "\\$\\{viewName\\}", getDashboard().getViewName());
+                effectiveUrl = effectiveUrl.replaceAll("\\$\\{jobsList\\}", jobsListAsString());
+            } else {
+                effectiveUrl = iframeSource;
+            }
+        } else {
+            effectiveUrl = null;
+        }
+    }
+
+    private String jobsListAsString() {
+        StringBuilder sb = new StringBuilder();
+        Iterator<Job> jobs = getDashboard().getJobs().iterator();
+        if (jobs.hasNext()) {
+            sb.append(jobs.next().getName());
+        }
+        while (jobs.hasNext()) {
+            sb.append(",");
+            sb.append(jobs.next().getName());
+        }
+        return sb.toString();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_IframePortlet();
+        }
+
+        public FormValidation doCheckIframeSource(@QueryParameter String value) {
+            String error = getUrlError(value);
+            if (error != null) {
+                return FormValidation.error(error);
+            }
+            return FormValidation.ok();
+        }
+    }
+
+    /**
+     * Checks if the passed string is a valid HTTP or relative URL.
+     *
+     * @return Localized error message or null if URL is valid.
+     */
+    @CheckForNull
+    protected static final String getUrlError(String url) {
+        if (StringUtils.isBlank(url)) {
+            return Messages.Dashboard_UrlEmpty();
+        }
+        try {
+            final URI allowedUrl = new URI(url);
+            final String protocol = allowedUrl.getScheme();
+            if (!allowedUrl.isAbsolute() || protocol.equals("http") || protocol.equals("https")) {
+                return null;
+            } else {
+                return Messages.Dashboard_UrlHttp();
+            }
+        } catch (URISyntaxException e) {
+            return Messages.Dashboard_UrlInvalid(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/core/ImagePortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/core/ImagePortlet.java
@@ -20,74 +20,75 @@ import org.kohsuke.stapler.QueryParameter;
  */
 public class ImagePortlet extends DashboardPortlet {
 
-  private String url;
+    private String url;
 
-  @DataBoundConstructor
-  public ImagePortlet(String name) {
-    super(name);
-  }
-
-  @Deprecated
-  public ImagePortlet(String name, String url) {
-    super(name);
-    this.url = url;
-  }
-
-  public String getImageUrl() {
-    return this.url;
-  }
-
-  @DataBoundSetter
-  public void setImageUrl(final String url) {
-    this.url = url;
-  }
-
-  @Deprecated @DataBoundSetter
-  public void setUrl(final String url) {
-    this.url = url;
-  }
-
-  public boolean isUrlValid() {
-    return getUrlError(url) == null;
-  }
-
-  @Extension
-  public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
-
-    @Override
-    public String getDisplayName() {
-      return Messages.Dashboard_Image();
+    @DataBoundConstructor
+    public ImagePortlet(String name) {
+        super(name);
     }
 
-    public FormValidation doCheckImageUrl(@QueryParameter String value) {
-      String error = getUrlError(value);
-      if (error != null) {
-        return FormValidation.error(error);
-      }
-      return FormValidation.ok();
+    @Deprecated
+    public ImagePortlet(String name, String url) {
+        super(name);
+        this.url = url;
     }
-  }
 
-  /**
-   * Checks if the passed string is a valid HTTP or relative URL.
-   *
-   * @return Localized error message or null if URL is valid.
-   */
-  @CheckForNull
-  private static final String getUrlError(String url) {
-    if (StringUtils.isBlank(url)) {
-      return Messages.Dashboard_ImageUrlEmpty();
+    public String getImageUrl() {
+        return this.url;
     }
-    try {
-      final URI allowedUrl = new URI(url);
-      final String protocol = allowedUrl.getScheme();
-      if (!allowedUrl.isAbsolute() || protocol.equals("http") || protocol.equals("https")) {
-        return null;
-      } else {
-        return Messages.Dashboard_ImageUrlHttp();
-      }
-    } catch (URISyntaxException e) {
-      return Messages.Dashboard_ImageUrlInvalid(e.getMessage());
+
+    @DataBoundSetter
+    public void setImageUrl(final String url) {
+        this.url = url;
     }
-  }
+
+    @Deprecated
+    @DataBoundSetter
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    public boolean isUrlValid() {
+        return getUrlError(url) == null;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_Image();
+        }
+
+        public FormValidation doCheckImageUrl(@QueryParameter String value) {
+            String error = getUrlError(value);
+            if (error != null) {
+                return FormValidation.error(error);
+            }
+            return FormValidation.ok();
+        }
+    }
+
+    /**
+     * Checks if the passed string is a valid HTTP or relative URL.
+     *
+     * @return Localized error message or null if URL is valid.
+     */
+    @CheckForNull
+    private static final String getUrlError(String url) {
+        if (StringUtils.isBlank(url)) {
+            return Messages.Dashboard_ImageUrlEmpty();
+        }
+        try {
+            final URI allowedUrl = new URI(url);
+            final String protocol = allowedUrl.getScheme();
+            if (!allowedUrl.isAbsolute() || protocol.equals("http") || protocol.equals("https")) {
+                return null;
+            } else {
+                return Messages.Dashboard_ImageUrlHttp();
+            }
+        } catch (URISyntaxException e) {
+            return Messages.Dashboard_ImageUrlInvalid(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/core/JobsPortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/core/JobsPortlet.java
@@ -18,58 +18,57 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class JobsPortlet extends DashboardPortlet {
 
-  private static final int MIN_COLUMN_COUNT = 3;
+    private static final int MIN_COLUMN_COUNT = 3;
 
-  private final int columnCount;
-  private boolean fillColumnFirst = false;
+    private final int columnCount;
+    private boolean fillColumnFirst = false;
 
-  @DataBoundConstructor
-  public JobsPortlet(String name, int columnCount, boolean fillColumnFirst) {
-    super(name);
-    this.columnCount = columnCount;
-    this.fillColumnFirst = fillColumnFirst;
-  }
-
-  public int getColumnCount() {
-    return columnCount <= 0 ? MIN_COLUMN_COUNT : columnCount;
-  }
-
-  public List<List<Job>> getJobs() {
-    List<Job> jobs = this.getDashboard().getJobs();
-    Collections.sort(
-        jobs, (p1, p2) -> p1.getDisplayName().compareToIgnoreCase(p2.getDisplayName()));
-
-    if (this.fillColumnFirst) {
-      return transposed(jobs);
-    } else {
-      return Lists.partition(jobs, this.getColumnCount());
-    }
-  }
-
-  private List<List<Job>> transposed(List<Job> jobs) {
-    int rowCount = (jobs.size() + 1) / this.getColumnCount();
-    List<List<Job>> result = new ArrayList<>(rowCount);
-    for (int i = 0; i < rowCount; i++) {
-      result.add(new ArrayList<>(this.getColumnCount()));
-    }
-    int c = 0;
-    for (Job job : jobs) {
-      result.get(c).add(job);
-      c = (c + 1) % rowCount;
-    }
-    return result;
-  }
-
-  @Extension
-  public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
-
-    public int getDefaultColumnCount() {
-      return MIN_COLUMN_COUNT;
+    @DataBoundConstructor
+    public JobsPortlet(String name, int columnCount, boolean fillColumnFirst) {
+        super(name);
+        this.columnCount = columnCount;
+        this.fillColumnFirst = fillColumnFirst;
     }
 
-    @Override
-    public String getDisplayName() {
-      return Messages.Dashboard_JobsGrid();
+    public int getColumnCount() {
+        return columnCount <= 0 ? MIN_COLUMN_COUNT : columnCount;
     }
-  }
+
+    public List<List<Job>> getJobs() {
+        List<Job> jobs = this.getDashboard().getJobs();
+        Collections.sort(jobs, (p1, p2) -> p1.getDisplayName().compareToIgnoreCase(p2.getDisplayName()));
+
+        if (this.fillColumnFirst) {
+            return transposed(jobs);
+        } else {
+            return Lists.partition(jobs, this.getColumnCount());
+        }
+    }
+
+    private List<List<Job>> transposed(List<Job> jobs) {
+        int rowCount = (jobs.size() + 1) / this.getColumnCount();
+        List<List<Job>> result = new ArrayList<>(rowCount);
+        for (int i = 0; i < rowCount; i++) {
+            result.add(new ArrayList<>(this.getColumnCount()));
+        }
+        int c = 0;
+        for (Job job : jobs) {
+            result.get(c).add(job);
+            c = (c + 1) % rowCount;
+        }
+        return result;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+
+        public int getDefaultColumnCount() {
+            return MIN_COLUMN_COUNT;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_JobsGrid();
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/core/UnstableJobsPortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/core/UnstableJobsPortlet.java
@@ -22,75 +22,75 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class UnstableJobsPortlet extends DashboardPortlet {
 
-  private static final Collection<ListViewColumn> COLUMNS =
-      Arrays.asList(new StatusColumn(), new WeatherColumn(), new JobColumn());
-  private boolean showOnlyFailedJobs = false;
-  private final boolean recurse;
+    private static final Collection<ListViewColumn> COLUMNS =
+            Arrays.asList(new StatusColumn(), new WeatherColumn(), new JobColumn());
+    private boolean showOnlyFailedJobs = false;
+    private final boolean recurse;
 
-  @DataBoundConstructor
-  public UnstableJobsPortlet(String name, boolean showOnlyFailedJobs, boolean recurse) {
-    super(name);
-    this.showOnlyFailedJobs = showOnlyFailedJobs;
-    this.recurse = recurse;
-  }
+    @DataBoundConstructor
+    public UnstableJobsPortlet(String name, boolean showOnlyFailedJobs, boolean recurse) {
+        super(name);
+        this.showOnlyFailedJobs = showOnlyFailedJobs;
+        this.recurse = recurse;
+    }
 
-  /** Given a list of all jobs, return just those that are unstable or worse. */
-  public Collection<Job> getUnstableJobs(Collection<? extends Item> allJobs) {
-    ArrayList<Job> unstableJobs = new ArrayList<>();
-    Result expected = this.showOnlyFailedJobs ? Result.FAILURE : Result.UNSTABLE;
+    /** Given a list of all jobs, return just those that are unstable or worse. */
+    public Collection<Job> getUnstableJobs(Collection<? extends Item> allJobs) {
+        ArrayList<Job> unstableJobs = new ArrayList<>();
+        Result expected = this.showOnlyFailedJobs ? Result.FAILURE : Result.UNSTABLE;
 
-    for (Item item : allJobs) {
-      if (!(item instanceof TopLevelItem)) {
-        continue;
-      }
-      if (recurse && item instanceof ItemGroup) {
-        unstableJobs.addAll(getUnstableJobs(((ItemGroup<? extends Item>) item).getItems()));
-      }
-      if (item instanceof Job) {
-        Job job = (Job) item;
-        Run run = job.getLastCompletedBuild();
+        for (Item item : allJobs) {
+            if (!(item instanceof TopLevelItem)) {
+                continue;
+            }
+            if (recurse && item instanceof ItemGroup) {
+                unstableJobs.addAll(getUnstableJobs(((ItemGroup<? extends Item>) item).getItems()));
+            }
+            if (item instanceof Job) {
+                Job job = (Job) item;
+                Run run = job.getLastCompletedBuild();
 
-        if (run != null) {
-          Result result = run.getResult();
-          if (result != null && expected.isBetterOrEqualTo(result)) {
-            unstableJobs.add(job);
-          }
+                if (run != null) {
+                    Result result = run.getResult();
+                    if (result != null && expected.isBetterOrEqualTo(result)) {
+                        unstableJobs.add(job);
+                    }
+                }
+            }
         }
-      }
-    }
-    if (recurse) {
-      IdentityHashMap<Job, Object> duplicates = new IdentityHashMap<>(unstableJobs.size());
-      for (Iterator<Job> iterator = unstableJobs.iterator(); iterator.hasNext(); ) {
-        Job j = iterator.next();
-        if (duplicates.containsKey(j)) {
-          iterator.remove();
-        } else {
-          duplicates.put(j, null);
+        if (recurse) {
+            IdentityHashMap<Job, Object> duplicates = new IdentityHashMap<>(unstableJobs.size());
+            for (Iterator<Job> iterator = unstableJobs.iterator(); iterator.hasNext(); ) {
+                Job j = iterator.next();
+                if (duplicates.containsKey(j)) {
+                    iterator.remove();
+                } else {
+                    duplicates.put(j, null);
+                }
+            }
         }
-      }
+
+        return unstableJobs;
     }
 
-    return unstableJobs;
-  }
-
-  public Collection<ListViewColumn> getColumns() {
-    return COLUMNS;
-  }
-
-  public boolean isShowOnlyFailedJobs() {
-    return this.showOnlyFailedJobs;
-  }
-
-  public boolean isRecurse() {
-    return recurse;
-  }
-
-  @Extension
-  public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
-
-    @Override
-    public String getDisplayName() {
-      return Messages.Dashboard_UnstableJobs();
+    public Collection<ListViewColumn> getColumns() {
+        return COLUMNS;
     }
-  }
+
+    public boolean isShowOnlyFailedJobs() {
+        return this.showOnlyFailedJobs;
+    }
+
+    public boolean isRecurse() {
+        return recurse;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_UnstableJobs();
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/stats/StatBuilds.java
+++ b/src/main/java/hudson/plugins/view/dashboard/stats/StatBuilds.java
@@ -21,48 +21,48 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class StatBuilds extends DashboardPortlet {
 
-  /** The most builds we will try to examine. */
-  static final int MAX_BUILDS = Integer.getInteger(StatBuilds.class.getName() + ".maxBuilds", 10);
+    /** The most builds we will try to examine. */
+    static final int MAX_BUILDS = Integer.getInteger(StatBuilds.class.getName() + ".maxBuilds", 10);
 
-  @DataBoundConstructor
-  public StatBuilds(String name) {
-    super(name);
-  }
-
-  public Map<BallColor, Integer> getBuildStat(List<TopLevelItem> jobs) {
-    SortedMap<BallColor, Integer> colStatBuilds = new TreeMap<>();
-    for (BallColor color : BallColor.values()) {
-      colStatBuilds.put(color.noAnime(), 0);
+    @DataBoundConstructor
+    public StatBuilds(String name) {
+        super(name);
     }
-    // loop over jobs
-    for (TopLevelItem job : jobs) {
-      if (job instanceof Job) {
-        // Build statistics
-        List<Run> builds = ((Job) job).getBuilds().limit(MAX_BUILDS);
-        // loop over builds
-        for (Run build : builds) {
-          BallColor bColor = build.getIconColor();
-          if (bColor != null && bColor.noAnime() != null && colStatBuilds.get(bColor) != null) {
-            colStatBuilds.put(bColor.noAnime(), colStatBuilds.get(bColor) + 1);
-          }
+
+    public Map<BallColor, Integer> getBuildStat(List<TopLevelItem> jobs) {
+        SortedMap<BallColor, Integer> colStatBuilds = new TreeMap<>();
+        for (BallColor color : BallColor.values()) {
+            colStatBuilds.put(color.noAnime(), 0);
         }
-      }
+        // loop over jobs
+        for (TopLevelItem job : jobs) {
+            if (job instanceof Job) {
+                // Build statistics
+                List<Run> builds = ((Job) job).getBuilds().limit(MAX_BUILDS);
+                // loop over builds
+                for (Run build : builds) {
+                    BallColor bColor = build.getIconColor();
+                    if (bColor != null && bColor.noAnime() != null && colStatBuilds.get(bColor) != null) {
+                        colStatBuilds.put(bColor.noAnime(), colStatBuilds.get(bColor) + 1);
+                    }
+                }
+            }
+        }
+        return colStatBuilds;
     }
-    return colStatBuilds;
-  }
 
-  public float roundFloatDecimal(float input) {
-    float rounded = (float) Math.round(input * 100f);
-    rounded = rounded / 100f;
-    return rounded;
-  }
-
-  @Extension
-  public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
-
-    @Override
-    public String getDisplayName() {
-      return Messages.Dashboard_BuildStatistics();
+    public float roundFloatDecimal(float input) {
+        float rounded = (float) Math.round(input * 100f);
+        rounded = rounded / 100f;
+        return rounded;
     }
-  }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_BuildStatistics();
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/stats/StatJobs.java
+++ b/src/main/java/hudson/plugins/view/dashboard/stats/StatJobs.java
@@ -20,97 +20,96 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class StatJobs extends DashboardPortlet {
 
-   @DataBoundConstructor
-   public StatJobs(String name) {
-      super(name);
-   }
+    @DataBoundConstructor
+    public StatJobs(String name) {
+        super(name);
+    }
 
-   /**
-    * Heath status of the builds (use enum not class for it)
-    *
-    * FIXME: Should be refactored to not duplicate logic from Jenkins core.
-    *
-    * @deprecated Should be replaced with {@link hudson.model.HealthReport}
-    */
-   @Deprecated
-   public enum HealthStatus {
+    /**
+     * Heath status of the builds (use enum not class for it)
+     *
+     * FIXME: Should be refactored to not duplicate logic from Jenkins core.
+     *
+     * @deprecated Should be replaced with {@link hudson.model.HealthReport}
+     */
+    @Deprecated
+    public enum HealthStatus {
+        HEALTH_OVER_80("health-80plus.gif", Messages.Dashboard_NoRecentBuildsFailed()),
+        HEALTH_60_TO_79("health-60to79.gif", Messages.Dashboard_RecentBuildsFailed("20", "40")),
+        HEALTH_40_TO_59("health-40to59.gif", Messages.Dashboard_RecentBuildsFailed("40", "60")),
+        HEALTH_20_TO_39("health-20to39.gif", Messages.Dashboard_RecentBuildsFailed("60", "80")),
+        HEALTH_0_TO_19("health-00to19.gif", Messages.Dashboard_AllRecentBuildsFailed()),
+        HEALTH_UNKNOWN("empty.gif", Messages.Dashboard_UnknownStatus());
+        // private HealthReport healthReport;
+        private final String iconUrl;
+        private final String description;
 
-      HEALTH_OVER_80("health-80plus.gif", Messages.Dashboard_NoRecentBuildsFailed()),
-      HEALTH_60_TO_79("health-60to79.gif", Messages.Dashboard_RecentBuildsFailed("20", "40")),
-      HEALTH_40_TO_59("health-40to59.gif", Messages.Dashboard_RecentBuildsFailed("40", "60")),
-      HEALTH_20_TO_39("health-20to39.gif", Messages.Dashboard_RecentBuildsFailed("60", "80")),
-      HEALTH_0_TO_19("health-00to19.gif", Messages.Dashboard_AllRecentBuildsFailed()),
-      HEALTH_UNKNOWN("empty.gif", Messages.Dashboard_UnknownStatus());
-      // private HealthReport healthReport;
-      private final String iconUrl;
-      private final String description;
+        HealthStatus(String iconUrl, String description) {
+            this.iconUrl = iconUrl;
+            this.description = description;
+        }
 
-      HealthStatus(String iconUrl, String description) {
-         this.iconUrl = iconUrl;
-         this.description = description;
-      }
+        public static HealthStatus getHealthStatus(Job job) {
+            int score = job.getBuildHealth().getScore();
+            if (score <= 20) {
+                return HEALTH_0_TO_19;
+            }
+            if (score <= 40) {
+                return HEALTH_20_TO_39;
+            }
+            if (score <= 60) {
+                return HEALTH_40_TO_59;
+            }
+            if (score <= 80) {
+                return HEALTH_60_TO_79;
+            }
 
-      public static HealthStatus getHealthStatus(Job job) {
-         int score = job.getBuildHealth().getScore();
-         if (score <= 20) {
-            return HEALTH_0_TO_19;
-         }
-         if (score <= 40) {
-            return HEALTH_20_TO_39;
-         }
-         if (score <= 60) {
-            return HEALTH_40_TO_59;
-         }
-         if (score <= 80) {
-            return HEALTH_60_TO_79;
-         }
+            return job.getFirstBuild() != null ? HEALTH_OVER_80 : HEALTH_UNKNOWN;
+        }
 
-         return job.getFirstBuild() != null ? HEALTH_OVER_80 : HEALTH_UNKNOWN;
-      }
+        public String getIconUrl() {
+            return Hudson.RESOURCE_PATH + "/images/32x32/" + iconUrl;
+        }
 
-      public String getIconUrl() {
-         return Hudson.RESOURCE_PATH + "/images/32x32/" + iconUrl;
-      }
+        public String getIconUrl(String size) {
+            if (iconUrl == null) {
+                return Hudson.RESOURCE_PATH + "/images/" + size + "/" + HEALTH_UNKNOWN.getIconUrl();
+            }
+            if (iconUrl.startsWith("/")) {
+                return iconUrl.replace("/32x32/", "/" + size + "/");
+            }
+            return Hudson.RESOURCE_PATH + "/images/" + size + "/" + iconUrl;
+        }
 
-      public String getIconUrl(String size) {
-         if (iconUrl == null) {
-            return Hudson.RESOURCE_PATH + "/images/" + size + "/" + HEALTH_UNKNOWN.getIconUrl();
-         }
-         if (iconUrl.startsWith("/")) {
-            return iconUrl.replace("/32x32/", "/" + size + "/");
-         }
-         return Hudson.RESOURCE_PATH + "/images/" + size + "/" + iconUrl;
-      }
+        public String getDescription() {
+            return description;
+        }
+    }
 
-      public String getDescription() {
-         return description;
-      }
-   }
+    /**
+     * Project statistics - number of projects with given health status
+     */
+    public Map<HealthStatus, Integer> getJobStat(List<TopLevelItem> jobs) {
+        SortedMap<HealthStatus, Integer> colStatJobs = new TreeMap<HealthStatus, Integer>();
+        for (HealthStatus status : HealthStatus.values()) {
+            colStatJobs.put(status, 0);
+        }
+        // Job and build statistics
+        for (TopLevelItem job : jobs) {
+            if (job instanceof Job) {
+                HealthStatus status = HealthStatus.getHealthStatus(((Job) job));
+                colStatJobs.put(status, colStatJobs.get(status) + 1);
+            }
+        }
+        return colStatJobs;
+    }
 
-   /**
-    * Project statistics - number of projects with given health status
-    */
-   public Map<HealthStatus, Integer> getJobStat(List<TopLevelItem> jobs) {
-      SortedMap<HealthStatus, Integer> colStatJobs = new TreeMap<HealthStatus, Integer>();
-      for (HealthStatus status : HealthStatus.values()) {
-         colStatJobs.put(status, 0);
-      }
-      // Job and build statistics
-      for (TopLevelItem job : jobs) {
-         if (job instanceof Job) {
-            HealthStatus status = HealthStatus.getHealthStatus(((Job) job));
-            colStatJobs.put(status, colStatJobs.get(status) + 1);
-         }
-      }
-      return colStatJobs;
-   }
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
 
-   @Extension
-   public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
-
-      @Override
-      public String getDisplayName() {
-         return Messages.Dashboard_JobStatistics();
-      }
-   }
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_JobStatistics();
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/stats/StatSlaves.java
+++ b/src/main/java/hudson/plugins/view/dashboard/stats/StatSlaves.java
@@ -17,66 +17,77 @@ import org.kohsuke.stapler.export.ExportedBean;
 /** @author Lucie Votypkova */
 public class StatSlaves extends DashboardPortlet {
 
-  @DataBoundConstructor
-  public StatSlaves(String name) {
-    super(name);
-  }
-
-  @ExportedBean
-  public static final class AgentStats {
-    @Exported public final int agents;
-    @Exported public int onlineAgents = 0;
-    @Exported public int offlineAgents = 0;
-    @Exported public int disconnectedAgents = 0;
-    @Exported public final int tasksInQueue;
-    @Exported public final int runningJobs;
-
-    AgentStats(Jenkins j) {
-      agents = j.getNodes().size();
-      countAgents(j.getComputers());
-      tasksInQueue = j.getQueue().getItems().length;
-      runningJobs = countRunningJobs(j);
+    @DataBoundConstructor
+    public StatSlaves(String name) {
+        super(name);
     }
 
-    private void countAgents(Computer[] computers) {
-      for (Computer computer : computers) {
-        if (computer.isOnline()) {
-          onlineAgents++;
-        } else if (computer.getConnectTime() != 0) {
-          offlineAgents++;
-        } else {
-          disconnectedAgents++;
+    @ExportedBean
+    public static final class AgentStats {
+        @Exported
+        public final int agents;
+
+        @Exported
+        public int onlineAgents = 0;
+
+        @Exported
+        public int offlineAgents = 0;
+
+        @Exported
+        public int disconnectedAgents = 0;
+
+        @Exported
+        public final int tasksInQueue;
+
+        @Exported
+        public final int runningJobs;
+
+        AgentStats(Jenkins j) {
+            agents = j.getNodes().size();
+            countAgents(j.getComputers());
+            tasksInQueue = j.getQueue().getItems().length;
+            runningJobs = countRunningJobs(j);
         }
-      }
-      onlineAgents--;
-    }
 
-    private int countRunningJobs(Jenkins j) {
-      // TODO: Might be a faster way to get this info from the computers
-      int countRunningJobs = 0;
-      // We don't really care about security here as all this returns is a count
-      try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
-        for (Job job : j.allItems(Job.class)) {
-          if (job.isBuilding()) {
-            countRunningJobs++;
-          }
+        private void countAgents(Computer[] computers) {
+            for (Computer computer : computers) {
+                if (computer.isOnline()) {
+                    onlineAgents++;
+                } else if (computer.getConnectTime() != 0) {
+                    offlineAgents++;
+                } else {
+                    disconnectedAgents++;
+                }
+            }
+            onlineAgents--;
         }
-      }
-      return countRunningJobs;
+
+        private int countRunningJobs(Jenkins j) {
+            // TODO: Might be a faster way to get this info from the computers
+            int countRunningJobs = 0;
+            // We don't really care about security here as all this returns is a count
+            try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
+                for (Job job : j.allItems(Job.class)) {
+                    if (job.isBuilding()) {
+                        countRunningJobs++;
+                    }
+                }
+            }
+            return countRunningJobs;
+        }
     }
-  }
 
-  @JavaScriptMethod
-  public AgentStats getStats() {
-    return new AgentStats(Jenkins.get());
-  }
-
-  @Extension
-  public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
-
-    @Override
-    public String getDisplayName() {
-      return Messages.Dashboard_AgentStatistics();
+    @JavaScriptMethod
+    public AgentStats getStats() {
+        return new AgentStats(Jenkins.get());
     }
-  }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_AgentStatistics();
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/test/LocalDateLabel.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/LocalDateLabel.java
@@ -25,6 +25,7 @@ public class LocalDateLabel implements Comparable<LocalDateLabel> {
     }
 
     /** {@inheritDoc} */
+    @Override
     public int compareTo(final LocalDateLabel o) {
         return date.compareTo(o.date);
     }
@@ -56,12 +57,11 @@ public class LocalDateLabel implements Comparable<LocalDateLabel> {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        LocalDateLabel other = (LocalDateLabel)obj;
+        LocalDateLabel other = (LocalDateLabel) obj;
         if (date == null) {
-          return other.date == null;
+            return other.date == null;
+        } else {
+            return date.equals(other.date);
         }
-        else
-          return date.equals(other.date);
     }
 }
-

--- a/src/main/java/hudson/plugins/view/dashboard/test/TestResult.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/TestResult.java
@@ -4,51 +4,51 @@ import hudson.model.Job;
 
 public class TestResult {
 
-  private final Job job;
-  protected int tests;
-  protected int success;
-  protected int failed;
-  protected int skipped;
+    private final Job job;
+    protected int tests;
+    protected int success;
+    protected int failed;
+    protected int skipped;
 
-  public TestResult(Job job, int tests, int failed, int skipped) {
-    super();
-    this.job = job;
-    this.tests = tests;
-    this.failed = failed;
-    this.skipped = skipped;
+    public TestResult(Job job, int tests, int failed, int skipped) {
+        super();
+        this.job = job;
+        this.tests = tests;
+        this.failed = failed;
+        this.skipped = skipped;
 
-    this.success = tests - failed - skipped;
-  }
+        this.success = tests - failed - skipped;
+    }
 
-  public Job getJob() {
-    return job;
-  }
+    public Job getJob() {
+        return job;
+    }
 
-  public int getTests() {
-    return tests;
-  }
+    public int getTests() {
+        return tests;
+    }
 
-  public int getSuccess() {
-    return success;
-  }
+    public int getSuccess() {
+        return success;
+    }
 
-  public double getSuccessPct() {
-    return tests != 0 ? ((double) success / tests) : 0d;
-  }
+    public double getSuccessPct() {
+        return tests != 0 ? ((double) success / tests) : 0d;
+    }
 
-  public int getFailed() {
-    return failed;
-  }
+    public int getFailed() {
+        return failed;
+    }
 
-  public double getFailedPct() {
-    return tests != 0 ? ((double) failed / tests) : 0d;
-  }
+    public double getFailedPct() {
+        return tests != 0 ? ((double) failed / tests) : 0d;
+    }
 
-  public int getSkipped() {
-    return skipped;
-  }
+    public int getSkipped() {
+        return skipped;
+    }
 
-  public double getSkippedPct() {
-    return tests != 0 ? ((double) skipped / tests) : 0d;
-  }
+    public double getSkippedPct() {
+        return tests != 0 ? ((double) skipped / tests) : 0d;
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/test/TestResultSummary.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/TestResultSummary.java
@@ -5,25 +5,24 @@ import java.util.List;
 
 public class TestResultSummary extends TestResult {
 
-  private final List<TestResult> testResults = new ArrayList<>();
+    private final List<TestResult> testResults = new ArrayList<>();
 
-  public TestResultSummary() {
-    super(null, 0, 0, 0);
-  }
+    public TestResultSummary() {
+        super(null, 0, 0, 0);
+    }
 
-  public TestResultSummary addTestResult(TestResult testResult) {
-    testResults.add(testResult);
+    public TestResultSummary addTestResult(TestResult testResult) {
+        testResults.add(testResult);
 
-    tests += testResult.getTests();
-    success += testResult.getSuccess();
-    failed += testResult.getFailed();
-    skipped += testResult.getSkipped();
+        tests += testResult.getTests();
+        success += testResult.getSuccess();
+        failed += testResult.getFailed();
+        skipped += testResult.getSkipped();
 
-    return this;
-  }
+        return this;
+    }
 
-  public List<TestResult> getTestResults() {
-    return testResults;
-  }
+    public List<TestResult> getTestResults() {
+        return testResults;
+    }
 }
-

--- a/src/main/java/hudson/plugins/view/dashboard/test/TestStatisticsChart.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/TestStatisticsChart.java
@@ -19,75 +19,74 @@ import org.jfree.chart.plot.PiePlot;
 import org.jfree.data.general.DefaultPieDataset;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import hudson.plugins.view.dashboard.Messages;
-
 public class TestStatisticsChart extends DashboardPortlet {
 
-   @DataBoundConstructor
-   public TestStatisticsChart(String name) {
-      super(name);
-   }
+    @DataBoundConstructor
+    public TestStatisticsChart(String name) {
+        super(name);
+    }
 
-   /**
-    * Graph of duration of tests over time.
-    */
-   public Graph getSummaryGraph() {
-      final TestResultSummary summary = TestUtil.getTestResultSummary(getDashboard().getItems(), false);
+    /**
+     * Graph of duration of tests over time.
+     */
+    public Graph getSummaryGraph() {
+        final TestResultSummary summary =
+                TestUtil.getTestResultSummary(getDashboard().getItems(), false);
 
-      return new Graph(-1, 300, 220) {
+        return new Graph(-1, 300, 220) {
 
-         @Override
-         protected JFreeChart createGraph() {
-            DefaultPieDataset dataset = new DefaultPieDataset();
-            dataset.setValue(Messages.Dashboard_Success(), summary.getSuccess());
-            dataset.setValue(Messages.Dashboard_Skipped(), summary.getSkipped());
-            dataset.setValue(Messages.Dashboard_Failed(), summary.getFailed());
-            JFreeChart chart = ChartFactory.createPieChart(null, dataset, false, false, false);
+            @Override
+            protected JFreeChart createGraph() {
+                DefaultPieDataset dataset = new DefaultPieDataset();
+                dataset.setValue(Messages.Dashboard_Success(), summary.getSuccess());
+                dataset.setValue(Messages.Dashboard_Skipped(), summary.getSkipped());
+                dataset.setValue(Messages.Dashboard_Failed(), summary.getFailed());
+                JFreeChart chart = ChartFactory.createPieChart(null, dataset, false, false, false);
 
-            chart.setBackgroundPaint(Color.white);
+                chart.setBackgroundPaint(Color.white);
 
-            final PiePlot plot = (PiePlot) chart.getPlot();
+                final PiePlot plot = (PiePlot) chart.getPlot();
 
-            // plot.setAxisOffset(new Spacer(Spacer.ABSOLUTE, 5.0, 5.0, 5.0, 5.0));
-            plot.setBackgroundPaint(Color.WHITE);
-            plot.setOutlinePaint(null);
-            plot.setForegroundAlpha(0.8f);
+                // plot.setAxisOffset(new Spacer(Spacer.ABSOLUTE, 5.0, 5.0, 5.0, 5.0));
+                plot.setBackgroundPaint(Color.WHITE);
+                plot.setOutlinePaint(null);
+                plot.setForegroundAlpha(0.8f);
 
-            // create arraylist of paint color, adding only color if related stat is > 0
-            List<Paint> paints = new ArrayList<Paint>();
-            if (summary.getSuccess() > 0) {
-               paints.add(ColorPalette.BLUE);
+                // create arraylist of paint color, adding only color if related stat is > 0
+                List<Paint> paints = new ArrayList<Paint>();
+                if (summary.getSuccess() > 0) {
+                    paints.add(ColorPalette.BLUE);
+                }
+                if (summary.getSkipped() > 0) {
+                    paints.add(ColorPalette.YELLOW);
+                }
+                if (summary.getFailed() > 0) {
+                    paints.add(ColorPalette.RED);
+                }
+
+                DefaultDrawingSupplier ds = new DefaultDrawingSupplier(
+                        paints.toArray(new Paint[0]),
+                        DefaultDrawingSupplier.DEFAULT_OUTLINE_PAINT_SEQUENCE,
+                        DefaultDrawingSupplier.DEFAULT_STROKE_SEQUENCE,
+                        DefaultDrawingSupplier.DEFAULT_OUTLINE_STROKE_SEQUENCE,
+                        DefaultDrawingSupplier.DEFAULT_SHAPE_SEQUENCE);
+                plot.setDrawingSupplier(ds);
+
+                plot.setLabelGenerator(new StandardPieSectionLabelGenerator(
+                        "{0} = {1} ({2})", NumberFormat.getNumberInstance(), NumberFormat.getPercentInstance()));
+                plot.setNoDataMessage(Messages.Dashboard_NoDataAvailable());
+
+                return chart;
             }
-            if (summary.getSkipped() > 0) {
-               paints.add(ColorPalette.YELLOW);
-            }
-            if (summary.getFailed() > 0) {
-               paints.add(ColorPalette.RED);
-            }
+        };
+    }
 
-            DefaultDrawingSupplier ds = new DefaultDrawingSupplier(
-                    paints.toArray(new Paint[0]),
-                    DefaultDrawingSupplier.DEFAULT_OUTLINE_PAINT_SEQUENCE,
-                    DefaultDrawingSupplier.DEFAULT_STROKE_SEQUENCE,
-                    DefaultDrawingSupplier.DEFAULT_OUTLINE_STROKE_SEQUENCE,
-                    DefaultDrawingSupplier.DEFAULT_SHAPE_SEQUENCE);
-            plot.setDrawingSupplier(ds);
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
 
-            plot.setLabelGenerator(new StandardPieSectionLabelGenerator(
-                    "{0} = {1} ({2})", NumberFormat.getNumberInstance(), NumberFormat.getPercentInstance()));
-            plot.setNoDataMessage(Messages.Dashboard_NoDataAvailable());
-
-            return chart;
-         }
-      };
-   }
-
-   @Extension
-   public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
-
-      @Override
-      public String getDisplayName() {
-         return Messages.Dashboard_TestStatisticsChart();
-      }
-   }
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_TestStatisticsChart();
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/test/TestStatisticsPortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/TestStatisticsPortlet.java
@@ -17,115 +17,115 @@ import org.kohsuke.stapler.DataBoundSetter;
  * @author Peter Hayes
  */
 public class TestStatisticsPortlet extends DashboardPortlet {
-  private boolean useBackgroundColors;
-  private String skippedColor;
-  private String successColor;
-  private String failureColor;
-  private final boolean hideZeroTestProjects;
-  private boolean useAlternatePercentagesOnLimits;
+    private boolean useBackgroundColors;
+    private String skippedColor;
+    private String successColor;
+    private String failureColor;
+    private final boolean hideZeroTestProjects;
+    private boolean useAlternatePercentagesOnLimits;
 
-  @DataBoundConstructor
-  public TestStatisticsPortlet(
-      String name,
-      final boolean hideZeroTestProjects,
-      String successColor,
-      String failureColor,
-      String skippedColor,
-      boolean useBackgroundColors) {
-    super(name);
-    this.successColor = successColor;
-    this.failureColor = failureColor;
-    this.skippedColor = skippedColor;
-    this.useBackgroundColors = useBackgroundColors;
-    this.hideZeroTestProjects = hideZeroTestProjects;
-  }
-
-  public TestResultSummary getTestResultSummary(Collection<TopLevelItem> jobs) {
-    return TestUtil.getTestResultSummary(jobs, hideZeroTestProjects);
-  }
-
-  public boolean getHideZeroTestProjects() {
-    return this.hideZeroTestProjects;
-  }
-
-  public String format(DecimalFormat df, double val) {
-    if (val < 1d && val > .99d) {
-      return useAlternatePercentagesOnLimits ? ">99%" : "<100%";
+    @DataBoundConstructor
+    public TestStatisticsPortlet(
+            String name,
+            final boolean hideZeroTestProjects,
+            String successColor,
+            String failureColor,
+            String skippedColor,
+            boolean useBackgroundColors) {
+        super(name);
+        this.successColor = successColor;
+        this.failureColor = failureColor;
+        this.skippedColor = skippedColor;
+        this.useBackgroundColors = useBackgroundColors;
+        this.hideZeroTestProjects = hideZeroTestProjects;
     }
-    if (val > 0d && val < .01d) {
-      return useAlternatePercentagesOnLimits ? "<1%" : ">0%";
+
+    public TestResultSummary getTestResultSummary(Collection<TopLevelItem> jobs) {
+        return TestUtil.getTestResultSummary(jobs, hideZeroTestProjects);
     }
-    return df.format(val);
-  }
 
-  public boolean isUseBackgroundColors() {
-    return useBackgroundColors;
-  }
-
-  public String getSuccessColor() {
-    return successColor;
-  }
-
-  public String getFailureColor() {
-    return failureColor;
-  }
-
-  public String getSkippedColor() {
-    return skippedColor;
-  }
-
-  @DataBoundSetter
-  public void setUseAlternatePercentagesOnLimits(boolean useAlternatePercentagesOnLimits) {
-    this.useAlternatePercentagesOnLimits = useAlternatePercentagesOnLimits;
-  }
-
-  public boolean isUseAlternatePercentagesOnLimits() {
-    return useAlternatePercentagesOnLimits;
-  }
-
-  public String getRowColor(TestResult testResult) {
-    if (testResult.failed > 0) {
-      return failureColor;
-    } else if (testResult.skipped > 0) {
-      return skippedColor;
-    } else {
-      return successColor;
+    public boolean getHideZeroTestProjects() {
+        return this.hideZeroTestProjects;
     }
-  }
 
-  public String getTotalRowColor(List<TestResult> testResults) {
-    for (TestResult testResult : testResults) {
-      if (testResult.failed > 0) {
+    public String format(DecimalFormat df, double val) {
+        if (val < 1d && val > .99d) {
+            return useAlternatePercentagesOnLimits ? ">99%" : "<100%";
+        }
+        if (val > 0d && val < .01d) {
+            return useAlternatePercentagesOnLimits ? "<1%" : ">0%";
+        }
+        return df.format(val);
+    }
+
+    public boolean isUseBackgroundColors() {
+        return useBackgroundColors;
+    }
+
+    public String getSuccessColor() {
+        return successColor;
+    }
+
+    public String getFailureColor() {
         return failureColor;
-      } else if (testResult.skipped > 0) {
+    }
+
+    public String getSkippedColor() {
         return skippedColor;
-      }
     }
-    return successColor;
-  }
 
-  public void setUseBackgroundColors(boolean useBackgroundColors) {
-    this.useBackgroundColors = useBackgroundColors;
-  }
-
-  public void setSkippedColor(String skippedColor) {
-    this.skippedColor = skippedColor;
-  }
-
-  public void setSuccessColor(String successColor) {
-    this.successColor = successColor;
-  }
-
-  public void setFailureColor(String failureColor) {
-    this.failureColor = failureColor;
-  }
-
-  @Extension
-  public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
-
-    @Override
-    public String getDisplayName() {
-      return Messages.Dashboard_TestStatisticsGrid();
+    @DataBoundSetter
+    public void setUseAlternatePercentagesOnLimits(boolean useAlternatePercentagesOnLimits) {
+        this.useAlternatePercentagesOnLimits = useAlternatePercentagesOnLimits;
     }
-  }
+
+    public boolean isUseAlternatePercentagesOnLimits() {
+        return useAlternatePercentagesOnLimits;
+    }
+
+    public String getRowColor(TestResult testResult) {
+        if (testResult.failed > 0) {
+            return failureColor;
+        } else if (testResult.skipped > 0) {
+            return skippedColor;
+        } else {
+            return successColor;
+        }
+    }
+
+    public String getTotalRowColor(List<TestResult> testResults) {
+        for (TestResult testResult : testResults) {
+            if (testResult.failed > 0) {
+                return failureColor;
+            } else if (testResult.skipped > 0) {
+                return skippedColor;
+            }
+        }
+        return successColor;
+    }
+
+    public void setUseBackgroundColors(boolean useBackgroundColors) {
+        this.useBackgroundColors = useBackgroundColors;
+    }
+
+    public void setSkippedColor(String skippedColor) {
+        this.skippedColor = skippedColor;
+    }
+
+    public void setSuccessColor(String successColor) {
+        this.successColor = successColor;
+    }
+
+    public void setFailureColor(String failureColor) {
+        this.failureColor = failureColor;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_TestStatisticsGrid();
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/test/TestTrendChart.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/TestTrendChart.java
@@ -39,291 +39,280 @@ import org.kohsuke.stapler.Stapler;
 
 public class TestTrendChart extends DashboardPortlet {
 
-  public enum DisplayStatus {
-    ALL("All"),
-    SUCCESS("Success"),
-    SKIPPED("Skipped"),
-    FAILED("Failed");
+    public enum DisplayStatus {
+        ALL("All"),
+        SUCCESS("Success"),
+        SKIPPED("Skipped"),
+        FAILED("Failed");
 
-    private final String description;
+        private final String description;
 
-    DisplayStatus(String description) {
-      this.description = description;
+        DisplayStatus(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getName() {
+            return name();
+        }
+
+        static {
+            Stapler.CONVERT_UTILS.register(new EnumConverter(), DisplayStatus.class);
+        }
     }
 
-    public String getDescription() {
-      return description;
+    private int graphWidth = 300;
+    private int graphHeight = 220;
+    private int dateRange = 365;
+    private int dateShift = 0;
+    private DisplayStatus displayStatus = DisplayStatus.ALL;
+
+    @DataBoundConstructor
+    public TestTrendChart(
+            String name, int graphWidth, int graphHeight, DisplayStatus displayStatus, int dateRange, int dateShift) {
+        super(name);
+        this.graphWidth = graphWidth;
+        this.graphHeight = graphHeight;
+        this.dateRange = dateRange;
+        this.dateShift = dateShift;
+        this.displayStatus = displayStatus;
+        DashboardLog.debug("TestTrendChart", "ctor");
     }
 
-    public String getName() {
-      return name();
+    public int getDateRange() {
+        return dateRange;
     }
 
-    static {
-      Stapler.CONVERT_UTILS.register(new EnumConverter(), DisplayStatus.class);
+    public int getDateShift() {
+        return dateShift;
     }
-  }
 
-  private int graphWidth = 300;
-  private int graphHeight = 220;
-  private int dateRange = 365;
-  private int dateShift = 0;
-  private DisplayStatus displayStatus = DisplayStatus.ALL;
+    public int getGraphWidth() {
+        return graphWidth <= 0 ? 300 : graphWidth;
+    }
 
-  @DataBoundConstructor
-  public TestTrendChart(
-      String name,
-      int graphWidth,
-      int graphHeight,
-      DisplayStatus displayStatus,
-      int dateRange,
-      int dateShift) {
-    super(name);
-    this.graphWidth = graphWidth;
-    this.graphHeight = graphHeight;
-    this.dateRange = dateRange;
-    this.dateShift = dateShift;
-    this.displayStatus = displayStatus;
-    DashboardLog.debug("TestTrendChart", "ctor");
-  }
+    public int getGraphHeight() {
+        return graphHeight <= 0 ? 220 : graphHeight;
+    }
 
-  public int getDateRange() {
-    return dateRange;
-  }
+    public DisplayStatus getDisplayStatus() {
+        return displayStatus;
+    }
 
-  public int getDateShift() {
-    return dateShift;
-  }
+    @VisibleForTesting
+    Map<LocalDate, TestResultSummary> collectData() {
+        // The standard equals doesn't work because two LocalDate objects can
+        // be differente even if the date is the same (different internal
+        // timestamp)
+        Comparator<LocalDate> localDateComparator = new Comparator<LocalDate>() {
 
-  public int getGraphWidth() {
-    return graphWidth <= 0 ? 300 : graphWidth;
-  }
-
-  public int getGraphHeight() {
-    return graphHeight <= 0 ? 220 : graphHeight;
-  }
-
-  public DisplayStatus getDisplayStatus() {
-    return displayStatus;
-  }
-
-  @VisibleForTesting
-  Map<LocalDate, TestResultSummary> collectData() {
-    // The standard equals doesn't work because two LocalDate objects can
-    // be differente even if the date is the same (different internal
-    // timestamp)
-    Comparator<LocalDate> localDateComparator =
-        new Comparator<LocalDate>() {
-
-          @Override
-          public int compare(LocalDate d1, LocalDate d2) {
-            if (d1.isEqual(d2)) {
-              return 0;
+            @Override
+            public int compare(LocalDate d1, LocalDate d2) {
+                if (d1.isEqual(d2)) {
+                    return 0;
+                }
+                if (d1.isAfter(d2)) {
+                    return 1;
+                }
+                return -1;
             }
-            if (d1.isAfter(d2)) {
-              return 1;
-            }
-            return -1;
-          }
         };
 
-    // We need a custom comparator for LocalDate objects
-    final Map<LocalDate, TestResultSummary> summaries =
-        new TreeMap<LocalDate, TestResultSummary>(localDateComparator);
-    LocalDate today = LocalDateTime.now().minus(dateShift * 6000, ChronoUnit.MILLIS).toLocalDate();
+        // We need a custom comparator for LocalDate objects
+        final Map<LocalDate, TestResultSummary> summaries =
+                new TreeMap<LocalDate, TestResultSummary>(localDateComparator);
+        LocalDate today =
+                LocalDateTime.now().minus(dateShift * 6000, ChronoUnit.MILLIS).toLocalDate();
 
-    // for each job, for each day, add last build of the day to summary
-    for (Job job : getDashboard().getJobs()) {
-      Run run = job.getFirstBuild();
+        // for each job, for each day, add last build of the day to summary
+        for (Job job : getDashboard().getJobs()) {
+            Run run = job.getFirstBuild();
 
-      if (run != null) { // execute only if job has builds
-        LocalDate runDay =
-            Instant.ofEpochMilli(run.getTimeInMillis())
-                .atZone(ZoneId.systemDefault())
-                .minus(dateShift * 60000L, ChronoUnit.MILLIS)
-                .toLocalDate();
-        LocalDate firstDay =
-            (dateRange != 0)
-                ? LocalDateTime.now()
-                    .minus(dateShift * 6000, ChronoUnit.MILLIS)
-                    .toLocalDate()
-                    .minusDays(dateRange)
-                : runDay;
+            if (run != null) { // execute only if job has builds
+                LocalDate runDay = Instant.ofEpochMilli(run.getTimeInMillis())
+                        .atZone(ZoneId.systemDefault())
+                        .minus(dateShift * 60000L, ChronoUnit.MILLIS)
+                        .toLocalDate();
+                LocalDate firstDay = (dateRange != 0)
+                        ? LocalDateTime.now()
+                                .minus(dateShift * 6000, ChronoUnit.MILLIS)
+                                .toLocalDate()
+                                .minusDays(dateRange)
+                        : runDay;
 
-        while (run != null) {
-          runDay =
-              Instant.ofEpochMilli(run.getTimeInMillis())
-                  .atZone(ZoneId.systemDefault())
-                  .minus(dateShift * 60000L, ChronoUnit.MILLIS)
-                  .toLocalDate();
-          Run nextRun = run.getNextBuild();
+                while (run != null) {
+                    runDay = Instant.ofEpochMilli(run.getTimeInMillis())
+                            .atZone(ZoneId.systemDefault())
+                            .minus(dateShift * 60000L, ChronoUnit.MILLIS)
+                            .toLocalDate();
+                    Run nextRun = run.getNextBuild();
 
-          if (nextRun != null) {
-            LocalDate nextRunDay =
-                Instant.ofEpochMilli(nextRun.getTimeInMillis())
-                    .atZone(ZoneId.systemDefault())
-                    .minus(dateShift * 60000L, ChronoUnit.MILLIS)
-                    .toLocalDate();
-            // skip run before firstDay, but keep if next build is
-            // after start date
-            if (!runDay.isBefore(firstDay)
-                || runDay.isBefore(firstDay) && !nextRunDay.isBefore(firstDay)) {
-              // if next run is not the same day, use this test to
-              // summarize
-              if (nextRunDay.isAfter(runDay)) {
-                summarize(
-                    summaries,
-                    run,
-                    (runDay.isBefore(firstDay) ? firstDay : runDay),
-                    nextRunDay.minusDays(1));
-              }
+                    if (nextRun != null) {
+                        LocalDate nextRunDay = Instant.ofEpochMilli(nextRun.getTimeInMillis())
+                                .atZone(ZoneId.systemDefault())
+                                .minus(dateShift * 60000L, ChronoUnit.MILLIS)
+                                .toLocalDate();
+                        // skip run before firstDay, but keep if next build is
+                        // after start date
+                        if (!runDay.isBefore(firstDay) || runDay.isBefore(firstDay) && !nextRunDay.isBefore(firstDay)) {
+                            // if next run is not the same day, use this test to
+                            // summarize
+                            if (nextRunDay.isAfter(runDay)) {
+                                summarize(
+                                        summaries,
+                                        run,
+                                        (runDay.isBefore(firstDay) ? firstDay : runDay),
+                                        nextRunDay.minusDays(1));
+                            }
+                        }
+                    } else {
+                        // use this run's test result from last run to today
+                        summarize(summaries, run, (runDay.isBefore(firstDay) ? firstDay : runDay), today);
+                    }
+
+                    run = nextRun;
+                }
             }
-          } else {
-            // use this run's test result from last run to today
-            summarize(summaries, run, (runDay.isBefore(firstDay) ? firstDay : runDay), today);
-          }
-
-          run = nextRun;
         }
-      }
+        return summaries;
     }
-    return summaries;
-  }
 
-  /** Graph of duration of tests over time. */
-  public Graph getSummaryGraph() {
-    final CategoryDataset data = buildDataSet(collectData());
+    /** Graph of duration of tests over time. */
+    public Graph getSummaryGraph() {
+        final CategoryDataset data = buildDataSet(collectData());
 
-    return new Graph(-1, getGraphWidth(), getGraphHeight()) {
+        return new Graph(-1, getGraphWidth(), getGraphHeight()) {
 
-      @Override
-      protected JFreeChart createGraph() {
-        final JFreeChart chart =
-            ChartFactory.createStackedAreaChart(
-                null, // chart title
-                Messages.Dashboard_Date(), // unused
-                Messages.Dashboard_Count(), // range axis label
-                data, // data
-                PlotOrientation.VERTICAL, // orientation
-                false, // include legend
-                false, // tooltips
-                false // urls
-                );
+            @Override
+            protected JFreeChart createGraph() {
+                final JFreeChart chart = ChartFactory.createStackedAreaChart(
+                        null, // chart title
+                        Messages.Dashboard_Date(), // unused
+                        Messages.Dashboard_Count(), // range axis label
+                        data, // data
+                        PlotOrientation.VERTICAL, // orientation
+                        false, // include legend
+                        false, // tooltips
+                        false // urls
+                        );
 
-        chart.setBackgroundPaint(Color.white);
+                chart.setBackgroundPaint(Color.white);
 
-        final CategoryPlot plot = chart.getCategoryPlot();
+                final CategoryPlot plot = chart.getCategoryPlot();
 
-        plot.setBackgroundPaint(Color.WHITE);
-        plot.setOutlinePaint(null);
-        plot.setForegroundAlpha(0.8f);
-        plot.setRangeGridlinesVisible(true);
-        plot.setRangeGridlinePaint(Color.black);
+                plot.setBackgroundPaint(Color.WHITE);
+                plot.setOutlinePaint(null);
+                plot.setForegroundAlpha(0.8f);
+                plot.setRangeGridlinesVisible(true);
+                plot.setRangeGridlinePaint(Color.black);
 
-        CategoryAxis domainAxis = new ShiftedCategoryAxis(null);
-        plot.setDomainAxis(domainAxis);
-        domainAxis.setCategoryLabelPositions(CategoryLabelPositions.UP_90);
-        domainAxis.setLowerMargin(0.0);
-        domainAxis.setUpperMargin(0.0);
-        domainAxis.setCategoryMargin(0.0);
+                CategoryAxis domainAxis = new ShiftedCategoryAxis(null);
+                plot.setDomainAxis(domainAxis);
+                domainAxis.setCategoryLabelPositions(CategoryLabelPositions.UP_90);
+                domainAxis.setLowerMargin(0.0);
+                domainAxis.setUpperMargin(0.0);
+                domainAxis.setCategoryMargin(0.0);
 
-        final NumberAxis rangeAxis = (NumberAxis) plot.getRangeAxis();
-        rangeAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
+                final NumberAxis rangeAxis = (NumberAxis) plot.getRangeAxis();
+                rangeAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
 
-        StackedAreaRenderer ar = new StackedAreaRenderer2();
-        plot.setRenderer(ar);
+                StackedAreaRenderer ar = new StackedAreaRenderer2();
+                plot.setRenderer(ar);
 
-        switch (getDisplayStatus()) {
-          case SUCCESS:
-            ar.setSeriesPaint(0, ColorPalette.BLUE);
-            break;
-          case SKIPPED:
-            ar.setSeriesPaint(0, ColorPalette.YELLOW);
-            break;
-          case FAILED:
-            ar.setSeriesPaint(0, ColorPalette.RED);
-            break;
-          default:
-            ar.setSeriesPaint(0, ColorPalette.RED); // Failures.
-            ar.setSeriesPaint(1, ColorPalette.YELLOW); // Skips.
-            ar.setSeriesPaint(2, ColorPalette.BLUE); // Total.
+                switch (getDisplayStatus()) {
+                    case SUCCESS:
+                        ar.setSeriesPaint(0, ColorPalette.BLUE);
+                        break;
+                    case SKIPPED:
+                        ar.setSeriesPaint(0, ColorPalette.YELLOW);
+                        break;
+                    case FAILED:
+                        ar.setSeriesPaint(0, ColorPalette.RED);
+                        break;
+                    default:
+                        ar.setSeriesPaint(0, ColorPalette.RED); // Failures.
+                        ar.setSeriesPaint(1, ColorPalette.YELLOW); // Skips.
+                        ar.setSeriesPaint(2, ColorPalette.BLUE); // Total.
+                }
+
+                // crop extra space around the graph
+                plot.setInsets(new RectangleInsets(0, 0, 0, 5.0));
+
+                return chart;
+            }
+        };
+    }
+
+    private CategoryDataset buildDataSet(Map<LocalDate, TestResultSummary> summaries) {
+        DataSetBuilder<String, LocalDateLabel> dsb = new DataSetBuilder<String, LocalDateLabel>();
+
+        for (Map.Entry<LocalDate, TestResultSummary> entry : summaries.entrySet()) {
+            LocalDateLabel label = new LocalDateLabel(entry.getKey());
+
+            switch (getDisplayStatus()) {
+                case SUCCESS:
+                    dsb.add(entry.getValue().getSuccess(), Messages.Dashboard_Total(), label);
+                    break;
+                case SKIPPED:
+                    dsb.add(entry.getValue().getSkipped(), Messages.Dashboard_Skipped(), label);
+                    break;
+                case FAILED:
+                    dsb.add(entry.getValue().getFailed(), Messages.Dashboard_Failed(), label);
+                    break;
+                default:
+                    dsb.add(entry.getValue().getSuccess(), Messages.Dashboard_Total(), label);
+                    dsb.add(entry.getValue().getFailed(), Messages.Dashboard_Failed(), label);
+                    dsb.add(entry.getValue().getSkipped(), Messages.Dashboard_Skipped(), label);
+            }
+        }
+        return dsb.build();
+    }
+
+    private void summarize(
+            Map<LocalDate, TestResultSummary> summaries, Run run, LocalDate firstDay, LocalDate lastDay) {
+        TestResult testResult = TestUtil.getTestResult(run);
+
+        // for every day between first day and last day inclusive
+        for (LocalDate curr = firstDay; curr.compareTo(lastDay) <= 0; curr = curr.plusDays(1)) {
+            if (testResult.getTests() != 0) {
+                TestResultSummary trs = summaries.get(curr);
+                if (trs == null) {
+                    trs = new TestResultSummary();
+                    summaries.put(curr, trs);
+                }
+
+                trs.addTestResult(testResult);
+            }
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Dashboard_TestTrendChart();
         }
 
-        // crop extra space around the graph
-        plot.setInsets(new RectangleInsets(0, 0, 0, 5.0));
-
-        return chart;
-      }
-    };
-  }
-
-  private CategoryDataset buildDataSet(Map<LocalDate, TestResultSummary> summaries) {
-    DataSetBuilder<String, LocalDateLabel> dsb = new DataSetBuilder<String, LocalDateLabel>();
-
-    for (Map.Entry<LocalDate, TestResultSummary> entry : summaries.entrySet()) {
-      LocalDateLabel label = new LocalDateLabel(entry.getKey());
-
-      switch (getDisplayStatus()) {
-        case SUCCESS:
-          dsb.add(entry.getValue().getSuccess(), Messages.Dashboard_Total(), label);
-          break;
-        case SKIPPED:
-          dsb.add(entry.getValue().getSkipped(), Messages.Dashboard_Skipped(), label);
-          break;
-        case FAILED:
-          dsb.add(entry.getValue().getFailed(), Messages.Dashboard_Failed(), label);
-          break;
-        default:
-          dsb.add(entry.getValue().getSuccess(), Messages.Dashboard_Total(), label);
-          dsb.add(entry.getValue().getFailed(), Messages.Dashboard_Failed(), label);
-          dsb.add(entry.getValue().getSkipped(), Messages.Dashboard_Skipped(), label);
-      }
-    }
-    return dsb.build();
-  }
-
-  private void summarize(
-      Map<LocalDate, TestResultSummary> summaries, Run run, LocalDate firstDay, LocalDate lastDay) {
-    TestResult testResult = TestUtil.getTestResult(run);
-
-    // for every day between first day and last day inclusive
-    for (LocalDate curr = firstDay; curr.compareTo(lastDay) <= 0; curr = curr.plusDays(1)) {
-      if (testResult.getTests() != 0) {
-        TestResultSummary trs = summaries.get(curr);
-        if (trs == null) {
-          trs = new TestResultSummary();
-          summaries.put(curr, trs);
+        public DisplayStatus getDefaultDisplayStatus() {
+            return DisplayStatus.ALL;
         }
 
-        trs.addTestResult(testResult);
-      }
+        /**
+         * Fills the jobExecutionMode drop-down menu.
+         *
+         * @return the jobExecutionMode items
+         */
+        public ListBoxModel doFillDisplayStatusItems() {
+            final ListBoxModel items = new ListBoxModel();
+            items.add(DisplayStatus.ALL.getDescription(), DisplayStatus.ALL.getName());
+            items.add(DisplayStatus.SUCCESS.getDescription(), DisplayStatus.SUCCESS.getName());
+            items.add(DisplayStatus.FAILED.getDescription(), DisplayStatus.FAILED.getName());
+            items.add(DisplayStatus.SKIPPED.getDescription(), DisplayStatus.SKIPPED.getName());
+            return items;
+        }
     }
-  }
-
-  @Extension
-  public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
-
-    @Override
-    public String getDisplayName() {
-      return Messages.Dashboard_TestTrendChart();
-    }
-
-    public DisplayStatus getDefaultDisplayStatus() {
-      return DisplayStatus.ALL;
-    }
-
-    /**
-     * Fills the jobExecutionMode drop-down menu.
-     *
-     * @return the jobExecutionMode items
-     */
-    public ListBoxModel doFillDisplayStatusItems() {
-      final ListBoxModel items = new ListBoxModel();
-      items.add(DisplayStatus.ALL.getDescription(), DisplayStatus.ALL.getName());
-      items.add(DisplayStatus.SUCCESS.getDescription(), DisplayStatus.SUCCESS.getName());
-      items.add(DisplayStatus.FAILED.getDescription(), DisplayStatus.FAILED.getName());
-      items.add(DisplayStatus.SKIPPED.getDescription(), DisplayStatus.SKIPPED.getName());
-      return items;
-    }
-  }
 }

--- a/src/main/java/hudson/plugins/view/dashboard/test/TestUtil.java
+++ b/src/main/java/hudson/plugins/view/dashboard/test/TestUtil.java
@@ -9,74 +9,71 @@ import hudson.tasks.test.TestResultProjectAction;
 import java.util.Collection;
 
 public class TestUtil {
-  /** "Cache" if matrix plugin is installed, so exception handling is only triggered once. */
-  private static boolean matrixPluginInstalled = true;
+    /** "Cache" if matrix plugin is installed, so exception handling is only triggered once. */
+    private static boolean matrixPluginInstalled = true;
 
-  /**
-   * Summarize the last test results from the passed set of jobs. If a job doesn't include any
-   * tests, add a 0 summary.
-   */
-  public static TestResultSummary getTestResultSummary(
-      Collection<TopLevelItem> jobs, boolean hideZeroTestProjects) {
-    TestResultSummary summary = new TestResultSummary();
+    /**
+     * Summarize the last test results from the passed set of jobs. If a job doesn't include any
+     * tests, add a 0 summary.
+     */
+    public static TestResultSummary getTestResultSummary(Collection<TopLevelItem> jobs, boolean hideZeroTestProjects) {
+        TestResultSummary summary = new TestResultSummary();
 
-    for (TopLevelItem item : jobs) {
-      if (isMatrixJob(item)) {
-        MatrixProject mp = (MatrixProject) item;
+        for (TopLevelItem item : jobs) {
+            if (isMatrixJob(item)) {
+                MatrixProject mp = (MatrixProject) item;
 
-        for (Job configuration : mp.getActiveConfigurations()) {
-          summarizeJob(configuration, summary, hideZeroTestProjects);
+                for (Job configuration : mp.getActiveConfigurations()) {
+                    summarizeJob(configuration, summary, hideZeroTestProjects);
+                }
+            } else if (item instanceof Job) {
+                Job job = (Job) item;
+                summarizeJob(job, summary, hideZeroTestProjects);
+            }
         }
-      } else if (item instanceof Job) {
-        Job job = (Job) item;
-        summarizeJob(job, summary, hideZeroTestProjects);
-      }
+
+        return summary;
     }
 
-    return summary;
-  }
+    private static void summarizeJob(Job job, TestResultSummary summary, boolean hideZeroTestProjects) {
+        boolean addBlank = true;
+        TestResultProjectAction testResults = job.getAction(TestResultProjectAction.class);
 
-  private static void summarizeJob(
-      Job job, TestResultSummary summary, boolean hideZeroTestProjects) {
-    boolean addBlank = true;
-    TestResultProjectAction testResults = job.getAction(TestResultProjectAction.class);
+        if (testResults != null) {
+            AbstractTestResultAction tra = testResults.getLastTestResultAction();
 
-    if (testResults != null) {
-      AbstractTestResultAction tra = testResults.getLastTestResultAction();
-
-      if (tra != null) {
-        addBlank = false;
-        if (tra.getTotalCount() > 0 || !hideZeroTestProjects) {
-          summary.addTestResult(
-              new TestResult(job, tra.getTotalCount(), tra.getFailCount(), tra.getSkipCount()));
+            if (tra != null) {
+                addBlank = false;
+                if (tra.getTotalCount() > 0 || !hideZeroTestProjects) {
+                    summary.addTestResult(
+                            new TestResult(job, tra.getTotalCount(), tra.getFailCount(), tra.getSkipCount()));
+                }
+            }
         }
-      }
+
+        if (addBlank && !hideZeroTestProjects) {
+            summary.addTestResult(new TestResult(job, 0, 0, 0));
+        }
     }
 
-    if (addBlank && !hideZeroTestProjects) {
-      summary.addTestResult(new TestResult(job, 0, 0, 0));
-    }
-  }
+    public static TestResult getTestResult(Run run) {
+        AbstractTestResultAction tra = run.getAction(AbstractTestResultAction.class);
+        if (tra != null) {
+            return new TestResult(run.getParent(), tra.getTotalCount(), tra.getFailCount(), tra.getSkipCount());
+        }
 
-  public static TestResult getTestResult(Run run) {
-    AbstractTestResultAction tra = run.getAction(AbstractTestResultAction.class);
-    if (tra != null) {
-      return new TestResult(
-          run.getParent(), tra.getTotalCount(), tra.getFailCount(), tra.getSkipCount());
+        return new TestResult(run.getParent(), 0, 0, 0);
     }
 
-    return new TestResult(run.getParent(), 0, 0, 0);
-  }
-
-  private static final boolean isMatrixJob(TopLevelItem item) {
-    if (!matrixPluginInstalled) {
-      return false;
+    private static final boolean isMatrixJob(TopLevelItem item) {
+        if (!matrixPluginInstalled) {
+            return false;
+        }
+        try {
+            return item instanceof MatrixProject;
+        } catch (NoClassDefFoundError x) {
+            matrixPluginInstalled = false;
+        }
+        return false;
     }
-    try {
-      return item instanceof MatrixProject;
-    } catch (NoClassDefFoundError x) {
-      matrixPluginInstalled = false;
-    }
-    return false;
-  }
 }

--- a/src/test/java/hudson/plugins/view/dashboard/ConfigurationAsCodeBackCompatTest.java
+++ b/src/test/java/hudson/plugins/view/dashboard/ConfigurationAsCodeBackCompatTest.java
@@ -1,24 +1,5 @@
 package hudson.plugins.view.dashboard;
 
-import hudson.plugins.view.dashboard.core.ImagePortlet;
-import io.jenkins.plugins.casc.ConfigurationAsCode;
-import io.jenkins.plugins.casc.ConfigurationContext;
-import io.jenkins.plugins.casc.ConfiguratorRegistry;
-import io.jenkins.plugins.casc.ObsoleteConfigurationMonitor;
-import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
-import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import io.jenkins.plugins.casc.misc.Util;
-import io.jenkins.plugins.casc.model.CNode;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
-
-import java.util.List;
-
 import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -30,57 +11,74 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.AllOf.allOf;
 
+import hudson.plugins.view.dashboard.core.ImagePortlet;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.ObsoleteConfigurationMonitor;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.Util;
+import io.jenkins.plugins.casc.model.CNode;
+import java.util.List;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
 public class ConfigurationAsCodeBackCompatTest {
 
-  @Rule
-  public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
 
+    @Test
+    @Issue("SECURITY-2233")
+    @ConfiguredWithCode("casc_image_backcompat_import.yml")
+    public void testOldImagePortletUrl() throws Exception {
+        Dashboard.DescriptorImpl descriptor = j.jenkins.getDescriptorByType(Dashboard.DescriptorImpl.class);
+        assertThat(descriptor, notNullValue());
 
-  @Test
-  @Issue("SECURITY-2233")
-  @ConfiguredWithCode("casc_image_backcompat_import.yml")
-  public void testOldImagePortletUrl() throws Exception {
-    Dashboard.DescriptorImpl descriptor =
-      j.jenkins.getDescriptorByType(Dashboard.DescriptorImpl.class);
-    assertThat(descriptor, notNullValue());
+        Dashboard dashboard = (Dashboard) j.jenkins.getView("test");
+        assertThat(dashboard.getViewName(), is("test"));
+        List<DashboardPortlet> leftPortlets = dashboard.getLeftPortlets();
+        assertThat(
+                leftPortlets.get(0),
+                allOf(
+                        instanceOf(ImagePortlet.class),
+                        hasProperty("name", equalTo("Image")),
+                        hasProperty("imageUrl", equalTo("test-backcompat"))));
 
-    Dashboard dashboard = (Dashboard) j.jenkins.getView("test");
-    assertThat(dashboard.getViewName(), is("test"));
-    List<DashboardPortlet> leftPortlets = dashboard.getLeftPortlets();
-    assertThat(leftPortlets.get(0), allOf(
-      instanceOf(ImagePortlet.class),
-      hasProperty("name", equalTo("Image")),
-      hasProperty("imageUrl", equalTo("test-backcompat"))
-    ));
+        final List<ObsoleteConfigurationMonitor.Error> errors =
+                ObsoleteConfigurationMonitor.get().getErrors();
+        assertThat(errors, containsInAnyOrder(new ErrorMatcher(containsString("'url' is deprecated"))));
 
-    final List<ObsoleteConfigurationMonitor.Error> errors = ObsoleteConfigurationMonitor.get().getErrors();
-    assertThat(errors, containsInAnyOrder(new ErrorMatcher(containsString("'url' is deprecated"))));
+        final ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        final ConfigurationContext context = new ConfigurationContext(registry);
+        CNode node = getJenkinsRoot(context).get("views").asSequence().get(0).asMapping();
 
-    final ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-    final ConfigurationContext context = new ConfigurationContext(registry);
-    CNode node = getJenkinsRoot(context).get("views").asSequence().get(0).asMapping();
+        final String exported = Util.toYamlString(node);
+        final String expected = Util.toStringFromYamlFile(this, "casc_image_backcompat_export.yml");
 
-    final String exported = Util.toYamlString(node);
-    final String expected = Util.toStringFromYamlFile(this, "casc_image_backcompat_export.yml");
-
-    assertThat(exported, is(expected));
-  }
-
-  static class ErrorMatcher extends TypeSafeDiagnosingMatcher<ObsoleteConfigurationMonitor.Error> {
-    final Matcher<String> messageMatcher;
-
-    public ErrorMatcher(final Matcher<String> messageMatcher) {
-      this.messageMatcher = messageMatcher;
+        assertThat(exported, is(expected));
     }
 
-    @Override
-    protected boolean matchesSafely(final ObsoleteConfigurationMonitor.Error item, final Description mismatchDescription) {
-      return messageMatcher.matches(item.message);
-    }
+    static class ErrorMatcher extends TypeSafeDiagnosingMatcher<ObsoleteConfigurationMonitor.Error> {
+        final Matcher<String> messageMatcher;
 
-    @Override
-    public void describeTo(final Description description) {
-      description.appendDescriptionOf(messageMatcher);
+        public ErrorMatcher(final Matcher<String> messageMatcher) {
+            this.messageMatcher = messageMatcher;
+        }
+
+        @Override
+        protected boolean matchesSafely(
+                final ObsoleteConfigurationMonitor.Error item, final Description mismatchDescription) {
+            return messageMatcher.matches(item.message);
+        }
+
+        @Override
+        public void describeTo(final Description description) {
+            description.appendDescriptionOf(messageMatcher);
+        }
     }
-  }
 }

--- a/src/test/java/hudson/plugins/view/dashboard/ConfigurationAsCodeTest.java
+++ b/src/test/java/hudson/plugins/view/dashboard/ConfigurationAsCodeTest.java
@@ -30,63 +30,62 @@ import org.junit.Test;
 
 public class ConfigurationAsCodeTest {
 
-  @ClassRule
-  @ConfiguredWithCode("casc.yml")
-  public static JenkinsConfiguredWithCodeRule rule = new JenkinsConfiguredWithCodeRule();
+    @ClassRule
+    @ConfiguredWithCode("casc.yml")
+    public static JenkinsConfiguredWithCodeRule rule = new JenkinsConfiguredWithCodeRule();
 
-  @Test
-  public void testImportConfiguration() {
-    Dashboard.DescriptorImpl descriptor =
-        rule.jenkins.getDescriptorByType(Dashboard.DescriptorImpl.class);
-    assertThat(descriptor, notNullValue());
+    @Test
+    public void testImportConfiguration() {
+        Dashboard.DescriptorImpl descriptor = rule.jenkins.getDescriptorByType(Dashboard.DescriptorImpl.class);
+        assertThat(descriptor, notNullValue());
 
-    Dashboard dashboard = (Dashboard) rule.jenkins.getView("test");
-    assertThat(dashboard.getViewName(), is("test"));
+        Dashboard dashboard = (Dashboard) rule.jenkins.getView("test");
+        assertThat(dashboard.getViewName(), is("test"));
 
-    assertThat(dashboard.isRecurse(), is(true));
-    assertThat(dashboard.isUseCssStyle(), is(true));
-    assertThat(dashboard.isIncludeStdJobList(), is(true));
-    assertThat(dashboard.isHideJenkinsPanels(), is(true));
-    assertThat(dashboard.getIncludeRegex(), is(".*"));
-    assertThat(dashboard.getLeftPortletWidth(), is("50%"));
-    assertThat(dashboard.getRightPortletWidth(), is("50%"));
+        assertThat(dashboard.isRecurse(), is(true));
+        assertThat(dashboard.isUseCssStyle(), is(true));
+        assertThat(dashboard.isIncludeStdJobList(), is(true));
+        assertThat(dashboard.isHideJenkinsPanels(), is(true));
+        assertThat(dashboard.getIncludeRegex(), is(".*"));
+        assertThat(dashboard.getLeftPortletWidth(), is("50%"));
+        assertThat(dashboard.getRightPortletWidth(), is("50%"));
 
-    List<DashboardPortlet> topPortlets = dashboard.getTopPortlets();
-    List<DashboardPortlet> leftPortlets = dashboard.getLeftPortlets();
-    List<DashboardPortlet> rightPortlets = dashboard.getRightPortlets();
-    List<DashboardPortlet> bottomPortlets = dashboard.getBottomPortlets();
+        List<DashboardPortlet> topPortlets = dashboard.getTopPortlets();
+        List<DashboardPortlet> leftPortlets = dashboard.getLeftPortlets();
+        List<DashboardPortlet> rightPortlets = dashboard.getRightPortlets();
+        List<DashboardPortlet> bottomPortlets = dashboard.getBottomPortlets();
 
-    assertThat(topPortlets.size(), is(3));
-    assertThat(leftPortlets.size(), is(2));
-    assertThat(rightPortlets.size(), is(4));
-    assertThat(bottomPortlets.size(), is(3));
+        assertThat(topPortlets.size(), is(3));
+        assertThat(leftPortlets.size(), is(2));
+        assertThat(rightPortlets.size(), is(4));
+        assertThat(bottomPortlets.size(), is(3));
 
-    assertThat(topPortlets.get(0), instanceOf(StatSlaves.class));
-    assertThat(topPortlets.get(1), instanceOf(StatBuilds.class));
-    assertThat(topPortlets.get(2), instanceOf(LatestBuilds.class));
+        assertThat(topPortlets.get(0), instanceOf(StatSlaves.class));
+        assertThat(topPortlets.get(1), instanceOf(StatBuilds.class));
+        assertThat(topPortlets.get(2), instanceOf(LatestBuilds.class));
 
-    assertThat(leftPortlets.get(0), instanceOf(IframePortlet.class));
-    assertThat(leftPortlets.get(1), instanceOf(ImagePortlet.class));
+        assertThat(leftPortlets.get(0), instanceOf(IframePortlet.class));
+        assertThat(leftPortlets.get(1), instanceOf(ImagePortlet.class));
 
-    assertThat(rightPortlets.get(0), instanceOf(HudsonStdJobsPortlet.class));
-    assertThat(rightPortlets.get(1), instanceOf(StatJobs.class));
-    assertThat(rightPortlets.get(2), instanceOf(JobsPortlet.class));
-    assertThat(rightPortlets.get(3), instanceOf(UnstableJobsPortlet.class));
+        assertThat(rightPortlets.get(0), instanceOf(HudsonStdJobsPortlet.class));
+        assertThat(rightPortlets.get(1), instanceOf(StatJobs.class));
+        assertThat(rightPortlets.get(2), instanceOf(JobsPortlet.class));
+        assertThat(rightPortlets.get(3), instanceOf(UnstableJobsPortlet.class));
 
-    assertThat(bottomPortlets.get(0), instanceOf(TestStatisticsChart.class));
-    assertThat(bottomPortlets.get(1), instanceOf(TestStatisticsPortlet.class));
-    assertThat(bottomPortlets.get(2), instanceOf(TestTrendChart.class));
-  }
+        assertThat(bottomPortlets.get(0), instanceOf(TestStatisticsChart.class));
+        assertThat(bottomPortlets.get(1), instanceOf(TestStatisticsPortlet.class));
+        assertThat(bottomPortlets.get(2), instanceOf(TestTrendChart.class));
+    }
 
-  @Test
-  public void testExportConfiguration() throws Exception {
-    final ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-    final ConfigurationContext context = new ConfigurationContext(registry);
-    CNode node = getJenkinsRoot(context).get("views").asSequence().get(0).asMapping();
+    @Test
+    public void testExportConfiguration() throws Exception {
+        final ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        final ConfigurationContext context = new ConfigurationContext(registry);
+        CNode node = getJenkinsRoot(context).get("views").asSequence().get(0).asMapping();
 
-    final String exported = Util.toYamlString(node);
-    final String expected = Util.toStringFromYamlFile(this, "casc-export.yml");
+        final String exported = Util.toYamlString(node);
+        final String expected = Util.toStringFromYamlFile(this, "casc-export.yml");
 
-    assertThat(exported, is(expected));
-  }
+        assertThat(exported, is(expected));
+    }
 }

--- a/src/test/java/hudson/plugins/view/dashboard/DashboardViewTest.java
+++ b/src/test/java/hudson/plugins/view/dashboard/DashboardViewTest.java
@@ -21,49 +21,47 @@ import org.xml.sax.SAXException;
 
 public class DashboardViewTest {
 
-  @ClassRule public static JenkinsRule j = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
 
-  static FreeStyleProject p1;
-  static FreeStyleProject p2;
+    static FreeStyleProject p1;
+    static FreeStyleProject p2;
 
-  @BeforeClass
-  public static void prepareJobs() throws Exception {
-    p1 = j.createFreeStyleProject("p1");
-    j.assertBuildStatusSuccess(p1.scheduleBuild2(0));
-    MockFolder f = j.createFolder("f1");
-    p2 = f.createProject(FreeStyleProject.class, "p2");
-    j.assertBuildStatusSuccess(p2.scheduleBuild2(0));
+    @BeforeClass
+    public static void prepareJobs() throws Exception {
+        p1 = j.createFreeStyleProject("p1");
+        j.assertBuildStatusSuccess(p1.scheduleBuild2(0));
+        MockFolder f = j.createFolder("f1");
+        p2 = f.createProject(FreeStyleProject.class, "p2");
+        j.assertBuildStatusSuccess(p2.scheduleBuild2(0));
 
-    for (int i = 0; i < 2; i++) {
-      Dashboard dashboard = new Dashboard("foo" + i);
-      dashboard.setIncludeRegex(".*");
-      dashboard.setRecurse(true);
-      dashboard.setIncludeStdJobList(true);
-      if (i % 2 == 0) {
-        j.jenkins.addView(dashboard);
-      } else {
-        f.addView(dashboard);
-      }
+        for (int i = 0; i < 2; i++) {
+            Dashboard dashboard = new Dashboard("foo" + i);
+            dashboard.setIncludeRegex(".*");
+            dashboard.setRecurse(true);
+            dashboard.setIncludeStdJobList(true);
+            if (i % 2 == 0) {
+                j.jenkins.addView(dashboard);
+            } else {
+                f.addView(dashboard);
+            }
+        }
     }
-  }
 
-  @Test
-  public void verifyDisplayNameInFolders() throws IOException, SAXException, InterruptedException {
-    HtmlPage page = j.createWebClient().goTo("view/foo0/");
-    HtmlAnchor p1Link = findLink(page, a -> a.getHrefAttribute().equals("job/p1/"));
-    assertThat(p1Link.getTextContent(), is(equalTo("p1")));
-    HtmlAnchor p2Link = findLink(page, a -> a.getHrefAttribute().endsWith("/job/p2/"));
-    assertThat(p2Link.getTextContent(), is(equalTo(p2.getFullDisplayName())));
+    @Test
+    public void verifyDisplayNameInFolders() throws IOException, SAXException, InterruptedException {
+        HtmlPage page = j.createWebClient().goTo("view/foo0/");
+        HtmlAnchor p1Link = findLink(page, a -> a.getHrefAttribute().equals("job/p1/"));
+        assertThat(p1Link.getTextContent(), is(equalTo("p1")));
+        HtmlAnchor p2Link = findLink(page, a -> a.getHrefAttribute().endsWith("/job/p2/"));
+        assertThat(p2Link.getTextContent(), is(equalTo(p2.getFullDisplayName())));
 
-    page = j.createWebClient().goTo("job/f1/view/foo1/");
-    p2Link = findLink(page, a -> a.getHrefAttribute().equals("job/p2/"));
-    assertThat(p2Link.getTextContent(), is(equalTo("p2")));
-  }
+        page = j.createWebClient().goTo("job/f1/view/foo1/");
+        p2Link = findLink(page, a -> a.getHrefAttribute().equals("job/p2/"));
+        assertThat(p2Link.getTextContent(), is(equalTo("p2")));
+    }
 
-  private static HtmlAnchor findLink(HtmlPage page, Predicate<HtmlAnchor> condition) {
-    return page.getAnchors().stream()
-        .filter(condition)
-        .findAny()
-        .orElseThrow(IllegalStateException::new);
-  }
+    private static HtmlAnchor findLink(HtmlPage page, Predicate<HtmlAnchor> condition) {
+        return page.getAnchors().stream().filter(condition).findAny().orElseThrow(IllegalStateException::new);
+    }
 }

--- a/src/test/java/hudson/plugins/view/dashboard/core/IFramePortletTest.java
+++ b/src/test/java/hudson/plugins/view/dashboard/core/IFramePortletTest.java
@@ -21,89 +21,88 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 
 public class IFramePortletTest {
-  @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  @Test
-  @Issue("SECURITY-2559")
-  public void iframePortletValidation() throws Exception {
-    j.createFreeStyleProject("bar");
+    @Test
+    @Issue("SECURITY-2559")
+    public void iframePortletValidation() throws Exception {
+        j.createFreeStyleProject("bar");
 
-    Dashboard dashboard = new Dashboard("dash1");
-    dashboard.setIncludeRegex(".*");
-    j.jenkins.addView(dashboard);
+        Dashboard dashboard = new Dashboard("dash1");
+        dashboard.setIncludeRegex(".*");
+        j.jenkins.addView(dashboard);
 
-    List<String> invalidUrls =
-        Arrays.asList(
-            "", "<img/src/onerror=alert(\"XSS\")>", "ftp://foo.com", "javascript:alert(1)");
+        List<String> invalidUrls =
+                Arrays.asList("", "<img/src/onerror=alert(\"XSS\")>", "ftp://foo.com", "javascript:alert(1)");
 
-    for (String invalid : invalidUrls) {
-      IframePortlet iframePortlet = new IframePortlet("bar", "");
-      iframePortlet.setIframeSource(invalid);
-      dashboard.getBottomPortlets().clear();
-      dashboard.getBottomPortlets().add(iframePortlet);
-      assertThat(iframePortlet.isIframeSourceValid(), is(false));
-      HtmlPage page = j.createWebClient().goTo("view/dash1/");
-      assertThat(findError(page), hasSize(1));
-      assertThat(findIFrame(page), is(emptyIterable()));
+        for (String invalid : invalidUrls) {
+            IframePortlet iframePortlet = new IframePortlet("bar", "");
+            iframePortlet.setIframeSource(invalid);
+            dashboard.getBottomPortlets().clear();
+            dashboard.getBottomPortlets().add(iframePortlet);
+            assertThat(iframePortlet.isIframeSourceValid(), is(false));
+            HtmlPage page = j.createWebClient().goTo("view/dash1/");
+            assertThat(findError(page), hasSize(1));
+            assertThat(findIFrame(page), is(emptyIterable()));
+        }
+
+        List<String> validUrls = Arrays.asList(j.getURL().toString(), j.getURL().toString() + "/job/bar");
+
+        for (String valid : validUrls) {
+            IframePortlet iframePortlet = new IframePortlet("bar", valid);
+            iframePortlet.setIframeSource(valid);
+            dashboard.getBottomPortlets().clear();
+            dashboard.getBottomPortlets().add(iframePortlet);
+            assertThat(valid + " is not valid", iframePortlet.isIframeSourceValid(), is(true));
+            HtmlPage page = j.createWebClient().goTo("view/dash1/");
+            assertThat(findError(page), is(emptyIterable()));
+            assertThat(findIFrame(page), hasSize(1));
+        }
     }
 
-    List<String> validUrls =
-        Arrays.asList(j.getURL().toString(), j.getURL().toString() + "/job/bar");
-
-    for (String valid : validUrls) {
-      IframePortlet iframePortlet = new IframePortlet("bar", valid);
-      iframePortlet.setIframeSource(valid);
-      dashboard.getBottomPortlets().clear();
-      dashboard.getBottomPortlets().add(iframePortlet);
-      assertThat(valid + " is not valid", iframePortlet.isIframeSourceValid(), is(true));
-      HtmlPage page = j.createWebClient().goTo("view/dash1/");
-      assertThat(findError(page), is(emptyIterable()));
-      assertThat(findIFrame(page), hasSize(1));
+    @WithoutJenkins
+    public void validateUri() throws Exception {
+        assertThat(IframePortlet.getUrlError("https://internal_host.example.com/foo"), nullValue());
+        assertThat(IframePortlet.getUrlError("//internal_host.example.com/foo"), nullValue());
+        assertThat(IframePortlet.getUrlError("file://internal_host.example.com/foo"), notNullValue());
+        assertThat(IframePortlet.getUrlError("ftp://internal_host.example.com/foo"), notNullValue());
+        assertThat(IframePortlet.getUrlError("//Users/foo/bar/beer"), nullValue());
+        assertThat(IframePortlet.getUrlError("ssh://internal_host.example.com/foo"), notNullValue());
+        assertThat(IframePortlet.getUrlError("<img/src/onerror=alert(\"XSS\")>"), notNullValue());
+        assertThat(IframePortlet.getUrlError("javascript:alert(1)"), notNullValue());
     }
-  }
 
-  @WithoutJenkins
-  public void validateUri() throws Exception {
-    assertThat(IframePortlet.getUrlError("https://internal_host.example.com/foo"), nullValue());
-    assertThat(IframePortlet.getUrlError("//internal_host.example.com/foo"), nullValue());
-    assertThat(IframePortlet.getUrlError("file://internal_host.example.com/foo"), notNullValue());
-    assertThat(IframePortlet.getUrlError("ftp://internal_host.example.com/foo"), notNullValue());
-    assertThat(IframePortlet.getUrlError("//Users/foo/bar/beer"), nullValue());
-    assertThat(IframePortlet.getUrlError("ssh://internal_host.example.com/foo"), notNullValue());
-    assertThat(IframePortlet.getUrlError("<img/src/onerror=alert(\"XSS\")>"), notNullValue());
-    assertThat(IframePortlet.getUrlError("javascript:alert(1)"), notNullValue());
-  }
+    @Test
+    @Issue("SECURITY-2565")
+    public void iframePortletSandbox() throws Exception {
+        j.createFreeStyleProject("bar");
 
-  @Test
-  @Issue("SECURITY-2565")
-  public void iframePortletSandbox() throws Exception {
-    j.createFreeStyleProject("bar");
+        Dashboard dashboard = new Dashboard("dash2");
+        dashboard.setIncludeRegex(".*");
+        j.jenkins.addView(dashboard);
 
-    Dashboard dashboard = new Dashboard("dash2");
-    dashboard.setIncludeRegex(".*");
-    j.jenkins.addView(dashboard);
-
-    for (String valid : Arrays.asList(j.getURL().toString(), j.getURL().toString() + "/job/bar")) {
-      IframePortlet iframePortlet = new IframePortlet("bar", valid);
-      iframePortlet.setIframeSource(valid);
-      dashboard.getBottomPortlets().clear();
-      dashboard.getBottomPortlets().add(iframePortlet);
-      assertThat(valid + " is not valid", iframePortlet.isIframeSourceValid(), is(true));
-      HtmlPage page = j.createWebClient().goTo("view/dash2/");
-      assertThat(findError(page), is(emptyIterable()));
-      assertThat(findIFrame(page), hasSize(1));
-      HtmlInlineFrame frameWindow = findIFrame(page).get(0);
-      String sanboxValue = frameWindow.getAttribute("sandbox");
-      assertThat("sandbox attribute not found", sanboxValue, notNullValue());
-      assertThat("sandbox attribute not empty", sanboxValue, emptyString());
+        for (String valid : Arrays.asList(j.getURL().toString(), j.getURL().toString() + "/job/bar")) {
+            IframePortlet iframePortlet = new IframePortlet("bar", valid);
+            iframePortlet.setIframeSource(valid);
+            dashboard.getBottomPortlets().clear();
+            dashboard.getBottomPortlets().add(iframePortlet);
+            assertThat(valid + " is not valid", iframePortlet.isIframeSourceValid(), is(true));
+            HtmlPage page = j.createWebClient().goTo("view/dash2/");
+            assertThat(findError(page), is(emptyIterable()));
+            assertThat(findIFrame(page), hasSize(1));
+            HtmlInlineFrame frameWindow = findIFrame(page).get(0);
+            String sanboxValue = frameWindow.getAttribute("sandbox");
+            assertThat("sandbox attribute not found", sanboxValue, notNullValue());
+            assertThat("sandbox attribute not empty", sanboxValue, emptyString());
+        }
     }
-  }
 
-  private List<HtmlInlineFrame> findIFrame(HtmlPage page) {
-    return page.getByXPath("//table[@id='portlet-bottomPortlets-0']//iframe");
-  }
+    private List<HtmlInlineFrame> findIFrame(HtmlPage page) {
+        return page.getByXPath("//table[@id='portlet-bottomPortlets-0']//iframe");
+    }
 
-  private List<DomNode> findError(HtmlPage page) {
-    return page.getByXPath("//div[@class='error']");
-  }
+    private List<DomNode> findError(HtmlPage page) {
+        return page.getByXPath("//div[@class='error']");
+    }
 }

--- a/src/test/java/hudson/plugins/view/dashboard/stats/StatBuildsTest.java
+++ b/src/test/java/hudson/plugins/view/dashboard/stats/StatBuildsTest.java
@@ -13,34 +13,35 @@ import org.jvnet.hudson.test.RunLoadCounter;
 
 public class StatBuildsTest {
 
-  @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  @Test
-  public void avoidEagerLoading() throws Exception {
-    final FreeStyleProject p = j.createFreeStyleProject();
-    RunLoadCounter.prepare(p);
-    for (int i = 0; i < 25; i++) {
-      j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    @Test
+    public void avoidEagerLoading() throws Exception {
+        final FreeStyleProject p = j.createFreeStyleProject();
+        RunLoadCounter.prepare(p);
+        for (int i = 0; i < 25; i++) {
+            j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        }
+        final StatBuilds stats = new StatBuilds("-");
+        assertEquals(
+                StatBuilds.MAX_BUILDS,
+                RunLoadCounter.assertMaxLoads(
+                                p,
+                                StatBuilds.MAX_BUILDS + /* margin for AbstractLazyLoadRunMap.headMap */ 2,
+                                () -> stats.getBuildStat(Collections.singletonList(p))
+                                        .get(BallColor.BLUE))
+                        .intValue());
     }
-    final StatBuilds stats = new StatBuilds("-");
-    assertEquals(
-        StatBuilds.MAX_BUILDS,
-        RunLoadCounter.assertMaxLoads(
-                p,
-                StatBuilds.MAX_BUILDS + /* margin for AbstractLazyLoadRunMap.headMap */ 2,
-                () -> stats.getBuildStat(Collections.singletonList(p)).get(BallColor.BLUE))
-            .intValue());
-  }
 
-  @Test
-  public void testGettingBuildStatsWithZeroBuild() throws Exception {
-    final FreeStyleProject project = j.createFreeStyleProject();
-    RunLoadCounter.prepare(project);
-    final StatBuilds stats = new StatBuilds("-");
-    final Map<BallColor, Integer> buildStats =
-        stats.getBuildStat(Collections.singletonList(project));
-    for (BallColor color : BallColor.values()) {
-      assertEquals((Integer) 0, buildStats.get(color.noAnime()));
+    @Test
+    public void testGettingBuildStatsWithZeroBuild() throws Exception {
+        final FreeStyleProject project = j.createFreeStyleProject();
+        RunLoadCounter.prepare(project);
+        final StatBuilds stats = new StatBuilds("-");
+        final Map<BallColor, Integer> buildStats = stats.getBuildStat(Collections.singletonList(project));
+        for (BallColor color : BallColor.values()) {
+            assertEquals((Integer) 0, buildStats.get(color.noAnime()));
+        }
     }
-  }
 }

--- a/src/test/java/hudson/plugins/view/dashboard/test/TestStatisticsPortletTest.java
+++ b/src/test/java/hudson/plugins/view/dashboard/test/TestStatisticsPortletTest.java
@@ -9,130 +9,112 @@ import org.junit.Test;
 
 public class TestStatisticsPortletTest {
 
-  /** Test of format method, of class TestStatisticsPortlet. */
-  @Test
-  public void testFormatLessThan1Percent() {
-    TestStatisticsPortlet instance =
-        new TestStatisticsPortlet("test", false, null, null, null, false);
-    DecimalFormat df = new DecimalFormat("0%");
-    double val = 0.003d;
-    String expResult = ">0%";
-    String result = instance.format(df, val);
-    assertEquals(expResult, result);
-  }
+    /** Test of format method, of class TestStatisticsPortlet. */
+    @Test
+    public void testFormatLessThan1Percent() {
+        TestStatisticsPortlet instance = new TestStatisticsPortlet("test", false, null, null, null, false);
+        DecimalFormat df = new DecimalFormat("0%");
+        double val = 0.003d;
+        String expResult = ">0%";
+        String result = instance.format(df, val);
+        assertEquals(expResult, result);
+    }
 
-  /** Test of format method, of class TestStatisticsPortlet. */
-  @Test
-  public void testAlternateFormatLessThan1Percent() {
-    TestStatisticsPortlet instance =
-        new TestStatisticsPortlet("test", false, null, null, null, false);
-    instance.setUseAlternatePercentagesOnLimits(true);
-    DecimalFormat df = new DecimalFormat("0%");
-    double val = 0.003d;
-    String expResult = "<1%";
-    String result = instance.format(df, val);
-    assertEquals(expResult, result);
-  }
+    /** Test of format method, of class TestStatisticsPortlet. */
+    @Test
+    public void testAlternateFormatLessThan1Percent() {
+        TestStatisticsPortlet instance = new TestStatisticsPortlet("test", false, null, null, null, false);
+        instance.setUseAlternatePercentagesOnLimits(true);
+        DecimalFormat df = new DecimalFormat("0%");
+        double val = 0.003d;
+        String expResult = "<1%";
+        String result = instance.format(df, val);
+        assertEquals(expResult, result);
+    }
 
-  /** Test of format method, of class TestStatisticsPortlet. */
-  @Test
-  public void testFormatBetween1PercentAnd99Percent() {
-    TestStatisticsPortlet instance =
-        new TestStatisticsPortlet("test", false, null, null, null, false);
-    DecimalFormat df = new DecimalFormat("0%");
-    double val = 0.5d;
-    String expResult = "50%";
-    String result = instance.format(df, val);
-    assertEquals(expResult, result);
-  }
+    /** Test of format method, of class TestStatisticsPortlet. */
+    @Test
+    public void testFormatBetween1PercentAnd99Percent() {
+        TestStatisticsPortlet instance = new TestStatisticsPortlet("test", false, null, null, null, false);
+        DecimalFormat df = new DecimalFormat("0%");
+        double val = 0.5d;
+        String expResult = "50%";
+        String result = instance.format(df, val);
+        assertEquals(expResult, result);
+    }
 
-  /** Test of format method, of class TestStatisticsPortlet. */
-  @Test
-  public void testFormatGreaterThan99Percent() {
-    TestStatisticsPortlet instance =
-        new TestStatisticsPortlet("test", false, null, null, null, false);
-    DecimalFormat df = new DecimalFormat("0%");
-    double val = 0.996d;
-    String expResult = "<100%";
-    String result = instance.format(df, val);
-    assertEquals(expResult, result);
-  }
+    /** Test of format method, of class TestStatisticsPortlet. */
+    @Test
+    public void testFormatGreaterThan99Percent() {
+        TestStatisticsPortlet instance = new TestStatisticsPortlet("test", false, null, null, null, false);
+        DecimalFormat df = new DecimalFormat("0%");
+        double val = 0.996d;
+        String expResult = "<100%";
+        String result = instance.format(df, val);
+        assertEquals(expResult, result);
+    }
 
-  /** Test of format method, of class TestStatisticsPortlet. */
-  @Test
-  public void testAlternateFormatGreaterThan99Percent() {
-    TestStatisticsPortlet instance =
-        new TestStatisticsPortlet("test", false, null, null, null, false);
-    instance.setUseAlternatePercentagesOnLimits(true);
-    DecimalFormat df = new DecimalFormat("0%");
-    double val = 0.996d;
-    String expResult = ">99%";
-    String result = instance.format(df, val);
-    assertEquals(expResult, result);
-  }
+    /** Test of format method, of class TestStatisticsPortlet. */
+    @Test
+    public void testAlternateFormatGreaterThan99Percent() {
+        TestStatisticsPortlet instance = new TestStatisticsPortlet("test", false, null, null, null, false);
+        instance.setUseAlternatePercentagesOnLimits(true);
+        DecimalFormat df = new DecimalFormat("0%");
+        double val = 0.996d;
+        String expResult = ">99%";
+        String result = instance.format(df, val);
+        assertEquals(expResult, result);
+    }
 
-  /** Test of format method, of class TestStatisticsPortlet. */
-  @Test
-  public void testFormatEqualTo100Percent() {
-    TestStatisticsPortlet instance =
-        new TestStatisticsPortlet("test", false, null, null, null, false);
-    DecimalFormat df = new DecimalFormat("0%");
-    double val = 1d;
-    String expResult = "100%";
-    String result = instance.format(df, val);
-    assertEquals(expResult, result);
-  }
+    /** Test of format method, of class TestStatisticsPortlet. */
+    @Test
+    public void testFormatEqualTo100Percent() {
+        TestStatisticsPortlet instance = new TestStatisticsPortlet("test", false, null, null, null, false);
+        DecimalFormat df = new DecimalFormat("0%");
+        double val = 1d;
+        String expResult = "100%";
+        String result = instance.format(df, val);
+        assertEquals(expResult, result);
+    }
 
-  /** Test of format method, of class TestStatisticsPortlet. */
-  @Test
-  public void testFormatEqualTo0Percent() {
-    TestStatisticsPortlet instance =
-        new TestStatisticsPortlet("test", false, null, null, null, false);
-    DecimalFormat df = new DecimalFormat("0%");
-    double val = 0d;
-    String expResult = "0%";
-    String result = instance.format(df, val);
-    assertEquals(expResult, result);
-  }
+    /** Test of format method, of class TestStatisticsPortlet. */
+    @Test
+    public void testFormatEqualTo0Percent() {
+        TestStatisticsPortlet instance = new TestStatisticsPortlet("test", false, null, null, null, false);
+        DecimalFormat df = new DecimalFormat("0%");
+        double val = 0d;
+        String expResult = "0%";
+        String result = instance.format(df, val);
+        assertEquals(expResult, result);
+    }
 
-  @Test
-  public void testRowColor() {
-    TestStatisticsPortlet instance =
-        new TestStatisticsPortlet("test", false, "green", "red", "orange", false);
-    assertEquals("green", instance.getRowColor(new TestResult(null, 3, 0, 0)));
-    assertEquals("red", instance.getRowColor(new TestResult(null, 1, 1, 0)));
-    assertEquals("orange", instance.getRowColor(new TestResult(null, 1, 0, 1)));
-  }
+    @Test
+    public void testRowColor() {
+        TestStatisticsPortlet instance = new TestStatisticsPortlet("test", false, "green", "red", "orange", false);
+        assertEquals("green", instance.getRowColor(new TestResult(null, 3, 0, 0)));
+        assertEquals("red", instance.getRowColor(new TestResult(null, 1, 1, 0)));
+        assertEquals("orange", instance.getRowColor(new TestResult(null, 1, 0, 1)));
+    }
 
-  @Test
-  public void testSummaryRowColorWithOneRow() {
-    TestStatisticsPortlet instance =
-        new TestStatisticsPortlet("test", false, "green", "red", "orange", false);
-    assertEquals(
-        "green",
-        instance.getTotalRowColor(Collections.singletonList(new TestResult(null, 3, 0, 0))));
-    assertEquals(
-        "red", instance.getTotalRowColor(Collections.singletonList(new TestResult(null, 1, 1, 0))));
-    assertEquals(
-        "orange",
-        instance.getTotalRowColor(Collections.singletonList(new TestResult(null, 1, 0, 1))));
-  }
+    @Test
+    public void testSummaryRowColorWithOneRow() {
+        TestStatisticsPortlet instance = new TestStatisticsPortlet("test", false, "green", "red", "orange", false);
+        assertEquals("green", instance.getTotalRowColor(Collections.singletonList(new TestResult(null, 3, 0, 0))));
+        assertEquals("red", instance.getTotalRowColor(Collections.singletonList(new TestResult(null, 1, 1, 0))));
+        assertEquals("orange", instance.getTotalRowColor(Collections.singletonList(new TestResult(null, 1, 0, 1))));
+    }
 
-  @Test
-  public void testSummaryRowColorWithMultipleRows() {
-    TestStatisticsPortlet instance =
-        new TestStatisticsPortlet("test", false, "green", "red", "orange", false);
-    assertEquals(
-        "green",
-        instance.getTotalRowColor(
-            Arrays.asList(new TestResult(null, 2, 0, 0), new TestResult(null, 2, 0, 0))));
-    assertEquals(
-        "red",
-        instance.getTotalRowColor(
-            Arrays.asList(new TestResult(null, 1, 0, 0), new TestResult(null, 1, 1, 0))));
-    assertEquals(
-        "orange",
-        instance.getTotalRowColor(
-            Arrays.asList(new TestResult(null, 1, 0, 0), new TestResult(null, 1, 0, 1))));
-  }
+    @Test
+    public void testSummaryRowColorWithMultipleRows() {
+        TestStatisticsPortlet instance = new TestStatisticsPortlet("test", false, "green", "red", "orange", false);
+        assertEquals(
+                "green",
+                instance.getTotalRowColor(Arrays.asList(new TestResult(null, 2, 0, 0), new TestResult(null, 2, 0, 0))));
+        assertEquals(
+                "red",
+                instance.getTotalRowColor(Arrays.asList(new TestResult(null, 1, 0, 0), new TestResult(null, 1, 1, 0))));
+        assertEquals(
+                "orange",
+                instance.getTotalRowColor(Arrays.asList(new TestResult(null, 1, 0, 0), new TestResult(null, 1, 0, 1))));
+    }
 }

--- a/src/test/java/hudson/plugins/view/dashboard/test/TestSummaryForMatrixJobs.java
+++ b/src/test/java/hudson/plugins/view/dashboard/test/TestSummaryForMatrixJobs.java
@@ -21,47 +21,41 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 
 public class TestSummaryForMatrixJobs {
-  @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  private MatrixProject matrixProject;
+    private MatrixProject matrixProject;
 
-  @Before
-  public void createMatrixJob() throws IOException {
-    matrixProject = j.jenkins.createProject(MatrixProject.class, "top");
-    matrixProject.getAxes().add(new TextAxis("param", "one", "two"));
-    matrixProject
-        .getBuildersList()
-        .add(
-            new TestBuilder() {
-              @Override
-              public boolean perform(
-                  AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
-                  throws InterruptedException, IOException {
-                build
-                    .getWorkspace()
-                    .child("testresult.xml")
-                    .copyFrom(
-                        TestSummaryForMatrixJobs.class.getResource(
-                            "/hudson/plugins/view/dashboard/test_failure.xml"));
+    @Before
+    public void createMatrixJob() throws IOException {
+        matrixProject = j.jenkins.createProject(MatrixProject.class, "top");
+        matrixProject.getAxes().add(new TextAxis("param", "one", "two"));
+        matrixProject.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
+                build.getWorkspace()
+                        .child("testresult.xml")
+                        .copyFrom(TestSummaryForMatrixJobs.class.getResource(
+                                "/hudson/plugins/view/dashboard/test_failure.xml"));
                 return true;
-              }
-            });
-    matrixProject.getPublishersList().add(new JUnitResultArchiver("testresult.xml"));
-  }
+            }
+        });
+        matrixProject.getPublishersList().add(new JUnitResultArchiver("testresult.xml"));
+    }
 
-  @Test
-  public void summaryIncludesMatrixJobs() throws Exception {
-    MatrixBuild result = matrixProject.scheduleBuild2(0).get();
-    j.assertBuildStatus(Result.UNSTABLE, result);
+    @Test
+    public void summaryIncludesMatrixJobs() throws Exception {
+        MatrixBuild result = matrixProject.scheduleBuild2(0).get();
+        j.assertBuildStatus(Result.UNSTABLE, result);
 
-    TestResultSummary testSummary =
-        TestUtil.getTestResultSummary(Collections.singleton(matrixProject), false);
-    assertThat(testSummary.getFailed(), is((2)));
-    assertThat(testSummary.getSuccess(), is((2)));
-  }
+        TestResultSummary testSummary = TestUtil.getTestResultSummary(Collections.singleton(matrixProject), false);
+        assertThat(testSummary.getFailed(), is((2)));
+        assertThat(testSummary.getSuccess(), is((2)));
+    }
 
-  @After
-  public void cleanupMatrixJob() throws IOException, InterruptedException {
-    matrixProject.delete();
-  }
+    @After
+    public void cleanupMatrixJob() throws IOException, InterruptedException {
+        matrixProject.delete();
+    }
 }

--- a/src/test/java/hudson/plugins/view/dashboard/test/TestSummaryForMavenJobs.java
+++ b/src/test/java/hudson/plugins/view/dashboard/test/TestSummaryForMavenJobs.java
@@ -14,21 +14,21 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
 
 public class TestSummaryForMavenJobs {
-  @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  @Test
-  public void summaryIncludesMavenJob() throws Exception {
-    ToolInstallations.configureMaven35();
+    @Test
+    public void summaryIncludesMavenJob() throws Exception {
+        ToolInstallations.configureMaven35();
 
-    MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "maven");
-    project.setGoals("test");
-    project.setScm(new ExtractResourceSCM(getClass().getResource("maven-unit-failure.zip")));
-    MavenModuleSetBuild build =
-        j.assertBuildStatus(Result.UNSTABLE, project.scheduleBuild2(0).get());
+        MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "maven");
+        project.setGoals("test");
+        project.setScm(new ExtractResourceSCM(getClass().getResource("maven-unit-failure.zip")));
+        MavenModuleSetBuild build =
+                j.assertBuildStatus(Result.UNSTABLE, project.scheduleBuild2(0).get());
 
-    TestResultSummary testSummary =
-        TestUtil.getTestResultSummary(Collections.singleton(project), false);
-    assertThat(testSummary.getFailed(), is(2));
-    assertThat(testSummary.getSuccess(), is(2));
-  }
+        TestResultSummary testSummary = TestUtil.getTestResultSummary(Collections.singleton(project), false);
+        assertThat(testSummary.getFailed(), is(2));
+        assertThat(testSummary.getSuccess(), is(2));
+    }
 }

--- a/src/test/java/hudson/plugins/view/dashboard/test/TestTrendChartTest.java
+++ b/src/test/java/hudson/plugins/view/dashboard/test/TestTrendChartTest.java
@@ -27,36 +27,38 @@ import org.mockito.quality.Strictness;
 
 public class TestTrendChartTest {
 
-  @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  @Rule public MockitoRule mockito = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
-  @Mock private Dashboard dashboard;
+    @Mock
+    private Dashboard dashboard;
 
-  // TODO: It would be nice to actually have some "history", but that would involve faking builds on
-  // different days
+    // TODO: It would be nice to actually have some "history", but that would involve faking builds on
+    // different days
 
-  @Test
-  public void summaryIncludesMavenJob() throws Exception {
-    ToolInstallations.configureMaven35();
+    @Test
+    public void summaryIncludesMavenJob() throws Exception {
+        ToolInstallations.configureMaven35();
 
-    MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "maven");
-    project.setGoals("test");
-    project.setScm(new ExtractResourceSCM(getClass().getResource("maven-unit-failure.zip")));
-    j.assertBuildStatus(Result.UNSTABLE, project.scheduleBuild2(0).get());
-    j.assertBuildStatus(Result.UNSTABLE, project.scheduleBuild2(0).get());
+        MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "maven");
+        project.setGoals("test");
+        project.setScm(new ExtractResourceSCM(getClass().getResource("maven-unit-failure.zip")));
+        j.assertBuildStatus(Result.UNSTABLE, project.scheduleBuild2(0).get());
+        j.assertBuildStatus(Result.UNSTABLE, project.scheduleBuild2(0).get());
 
-    when(dashboard.getJobs()).thenReturn(Collections.singletonList(project));
-    TestTrendChart chart =
-        new TestTrendChart("tests", 320, 240, TestTrendChart.DisplayStatus.ALL, 30, 0);
-    chart = spy(chart);
-    doReturn(dashboard).when(chart).getDashboard();
+        when(dashboard.getJobs()).thenReturn(Collections.singletonList(project));
+        TestTrendChart chart = new TestTrendChart("tests", 320, 240, TestTrendChart.DisplayStatus.ALL, 30, 0);
+        chart = spy(chart);
+        doReturn(dashboard).when(chart).getDashboard();
 
-    Map<LocalDate, TestResultSummary> chartData = chart.collectData();
-    Collection<TestResultSummary> values = chartData.values();
-    assertThat(values, Matchers.hasSize(1));
-    TestResultSummary today = values.iterator().next();
-    assertThat(today.getFailed(), is(equalTo(2)));
-    assertThat(today.getSuccess(), is(equalTo(2)));
-  }
+        Map<LocalDate, TestResultSummary> chartData = chart.collectData();
+        Collection<TestResultSummary> values = chartData.values();
+        assertThat(values, Matchers.hasSize(1));
+        TestResultSummary today = values.iterator().next();
+        assertThat(today.getFailed(), is(equalTo(2)));
+        assertThat(today.getSuccess(), is(equalTo(2)));
+    }
 }


### PR DESCRIPTION
As of https://github.com/jenkinsci/plugin-pom/pull/733 the upstream plugin parent POM provides a standard Spotless configuration that Jenkins plugins can opt into by adding a `.mvn_exec_spotless` file. This PR removes the custom Spotless configuration in this repository in favor of the upstream one and reformats the entire repository accordingly. The benefit of this PR is increased consistency and standardization with the rest of the Jenkins ecosystem. If this PR is accepted, the next step would be to check in a `.git-blame-ignore-revs` file so that this commit doesn't clutter up the Git blame view.