### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet.jelly
@@ -25,7 +25,10 @@
               </a>
               <script>
                 function build_${id}(img) {
-                  new Ajax.Request(img.parentNode.href);
+                  fetch(img.parentNode.href, {
+                    method: "post",
+                    headers: crumb.wrap({}),
+                  });
                   hoverNotification('${%Build scheduled}', img, -100);
                   return false;
                 }

--- a/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/portlet.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/portlet.jelly
@@ -35,7 +35,10 @@
                 </a>
                 <script>
                   function build_${id}(img) {
-                    new Ajax.Request(img.parentNode.href);
+                    fetch(img.parentNode.href, {
+                      method: "post",
+                      headers: crumb.wrap({}),
+                    });
                     hoverNotification('${%Build scheduled}', img, -100);
                     return false;
                   }


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. This PR is untested and in fact this functionality is already broken on recent cores due to changes in `<l:icon>` that predate the Prototype removal effort. So this PR merely merely implements the mechanical code change to preserve the status quo, to keep what was already broken from getting even more broken.