### PR TITLE
Adapt build buttons to core changes

### DIFF
--- a/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet.jelly
@@ -1,5 +1,11 @@
+<!--
+SPDX-FileCopyrightText: © 2009 Peter Hayes
+SPDX-FileCopyrightText: © 2010 Marco Ambu
+SPDX-FileCopyrightText: © 2023 TobiX <tobias-git@23.gs>
+SPDX-License-Identifier: MIT
+-->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
   xmlns:dp="/hudson/plugins/view/dashboard">
   <dp:decorate portlet="${it}" width="${w}">
     <j:forEach var="row" items="${it.jobs}">
@@ -7,29 +13,27 @@
         <j:forEach var="job" items="${row}">
           <td style="border: 1px solid #bbb;">
             <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
-              <j:set var="id" value="${h.generateId()}"/>
-              <a href="${job.shortUrl}build?delay=0sec">
-                <j:choose>
-                  <j:when test="${job.parameterized}">
-                    <j:set var="onclick" value="${null}"/>
-                  </j:when>
-                  <j:otherwise>
-                    <j:set var="onclick"
-                      value="return build_${id}(this)"/>
-                  </j:otherwise>
-                </j:choose>
-                <l:icon class="icon-clock icon-sm"
-                  title="${%Schedule a build}" alt="${%Schedule a build}"
-                  onclick="${onclick}"
-                  style="float: right; clear: none;"/>
+              <j:choose>
+                <j:when test="${job.parameterized}">
+                  <j:set var="title" value="${%Schedule_a_task_with_parameters(h.getRelativeDisplayNameFrom(job, itemGroup),job.taskNoun)}"/>
+                  <j:set var="buildNotification" value=""/>
+                  <j:set var="behaviourClass" value=""/>
+                </j:when>
+                <j:otherwise>
+                  <j:set var="title" value="${%Schedule_a_task(h.getRelativeDisplayNameFrom(job, itemGroup),job.taskNoun)}"/>
+                  <j:set var="buildNotification" value="${%Task_scheduled(job.taskNoun)}"/>
+                  <j:set var="behaviourClass" value="dashboard-view-job-portlet-build-button"/>
+                  <st:adjunct includes="hudson.plugins.view.dashboard.core.buildbutton"/>
+                </j:otherwise>
+              </j:choose>
+              <j:set var="isQueued" value="${app.queue.contains(job)}"/>
+              <a tooltip="${title}" class="${behaviourClass} jenkins-!-build-color"
+                data-notification="${buildNotification}"
+                href="${jobBaseUrl}${job.shortUrl}build?delay=0sec">
+                <span class="${isQueued ? 'pulse-animation': ''}">
+                  <l:icon src="symbol-play" class="icon-sm"/>
+                </span>
               </a>
-              <script>
-                function build_${id}(img) {
-                  new Ajax.Request(img.parentNode.href);
-                  hoverNotification('${%Build scheduled}', img, -100);
-                  return false;
-                }
-              </script>
             </j:if>
             <t:jobLink job="${job}"/>
           </td>

--- a/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet.properties
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet.properties
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: \u00A9 2023 TobiX <tobias-git@23.gs>
+# SPDX-License-Identifier: MIT
+Task_scheduled={0} scheduled
+Schedule_a_task=Schedule a {1} for {0}
+Schedule_a_task_with_parameters=Schedule a {1} with parameters for {0}

--- a/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet_ja.properties
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/JobsPortlet/portlet_ja.properties
@@ -1,23 +1,3 @@
-# The MIT License
-#
-# Copyright (c) 2012, Seiji Sogabe
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-
-Schedule\ a\ build=\u30d3\u30eb\u30c9\u5b9f\u884c
+# SPDX-FileCopyrightText: \u00A9 2012 Seiji Sogabe
+# SPDX-License-Identifier: MIT
+Schedule_a_task=\u30D3\u30EB\u30C9\u5B9F\u884C

--- a/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/portlet.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/portlet.jelly
@@ -1,5 +1,11 @@
+<!--
+SPDX-FileCopyrightText: © 2009 Peter Hayes
+SPDX-FileCopyrightText: © 2010 Marco Ambu
+SPDX-FileCopyrightText: © 2023 TobiX <tobias-git@23.gs>
+SPDX-License-Identifier: MIT
+-->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
   xmlns:dp="/hudson/plugins/view/dashboard">
   <dp:decorate portlet="${it}" width="4">
     <j:set var="columnExtensions" value="${it.columns}"/>
@@ -17,29 +23,27 @@
           <tr>
             <td style="${indenter.getCss(j)}; border: 1px solid #BBBBBB">
               <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
-                <j:set var="id" value="${h.generateId()}"/>
-                <a href="${job.shortUrl}build?delay=0sec">
-                  <j:choose>
-                    <j:when test="${job.parameterized}">
-                      <j:set var="onclick" value="${null}"/>
-                    </j:when>
-                    <j:otherwise>
-                      <j:set var="onclick"
-                        value="return build_${id}(this)"/>
-                    </j:otherwise>
-                  </j:choose>
-                  <l:icon class="icon-clock icon-sm"
-                    title="${%Schedule a build}" alt="${%Schedule a build}"
-                    onclick="${onclick}"
-                    style="float: right; clear: none;"/>
+                <j:choose>
+                  <j:when test="${job.parameterized}">
+                    <j:set var="title" value="${%Schedule_a_task_with_parameters(h.getRelativeDisplayNameFrom(job, itemGroup),job.taskNoun)}"/>
+                    <j:set var="buildNotification" value=""/>
+                    <j:set var="behaviourClass" value=""/>
+                  </j:when>
+                  <j:otherwise>
+                    <j:set var="title" value="${%Schedule_a_task(h.getRelativeDisplayNameFrom(job, itemGroup),job.taskNoun)}"/>
+                    <j:set var="buildNotification" value="${%Task_scheduled(job.taskNoun)}"/>
+                    <j:set var="behaviourClass" value="dashboard-view-job-portlet-build-button"/>
+                    <st:adjunct includes="hudson.plugins.view.dashboard.core.buildbutton"/>
+                  </j:otherwise>
+                </j:choose>
+                <j:set var="isQueued" value="${app.queue.contains(job)}"/>
+                <a tooltip="${title}" class="${behaviourClass} jenkins-!-build-color"
+                  data-notification="${buildNotification}"
+                  href="${jobBaseUrl}${job.shortUrl}build?delay=0sec">
+                  <span class="${isQueued ? 'pulse-animation': ''}">
+                    <l:icon src="symbol-play" class="icon-sm"/>
+                  </span>
                 </a>
-                <script>
-                  function build_${id}(img) {
-                    new Ajax.Request(img.parentNode.href);
-                    hoverNotification('${%Build scheduled}', img, -100);
-                    return false;
-                  }
-                </script>
               </j:if>
               <t:jobLink job="${job}"/>
             </td>

--- a/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/portlet.properties
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/portlet.properties
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: \u00A9 2023 TobiX <tobias-git@23.gs>
+# SPDX-License-Identifier: MIT
+Task_scheduled={0} scheduled
+Schedule_a_task=Schedule a {1} for {0}
+Schedule_a_task_with_parameters=Schedule a {1} with parameters for {0}

--- a/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/portlet_ja.properties
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/UnstableJobsPortlet/portlet_ja.properties
@@ -1,24 +1,4 @@
-# The MIT License
-#
-# Copyright (c) 2004-2010, Sun Microsystems, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-
-No\ unstable\ jobs=\u4e0d\u5b89\u5b9a\u30d3\u30eb\u30c9\u306a\u3057
-Schedule\ a\ build=\u30d3\u30eb\u30c9\u5b9f\u884c
+# SPDX-FileCopyrightText: \u00A9 2012 Seiji Sogabe
+# SPDX-License-Identifier: MIT
+No\ unstable\ jobs=\u4E0D\u5B89\u5B9A\u30D3\u30EB\u30C9\u306A\u3057
+Schedule_a_task=\u30D3\u30EB\u30C9\u5B9F\u884C

--- a/src/main/resources/hudson/plugins/view/dashboard/core/buildbutton.js
+++ b/src/main/resources/hudson/plugins/view/dashboard/core/buildbutton.js
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2023 TobiX <tobias-git@23.gs>
+// SPDX-License-Identifier: MIT
+
+Behaviour.specify(
+  ".dashboard-view-job-portlet-build-button",
+  "build-button",
+  0,
+  function (e) {
+    var url = e.getAttribute("href");
+    var message = e.getAttribute("data-notification");
+
+    e.onclick = function () {
+      fetch(url, {
+        method: "post",
+        headers: crumb.wrap({}),
+      });
+      hoverNotification(message, this, -100);
+      return false;
+    };
+  }
+);


### PR DESCRIPTION
This basically replaces the whole build button code by the current state in core:
- https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
- https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/views/BuildButtonColumn/icon.js

This integrates at least these changes:
- Replace inline JavaScript with adjuncts
- Modern tooltips
- Task nouns from core
- Replaces Prototype.js by fetch API
- Correct(?) icon colors
- New feature: Blinking icon if job is already queued

(Just realized that the config screens are still wonky)

### Testing done

Only manually tested under `mvn hpi:run`:
1. Created a dashboard with both a "Jobs Grid" and "Unstable Jobs"
2. Created sucessful/unsuccessful (non-)parametrized jobs
3. Validated that the build buttons for all 4 jobs work

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
