### PR TITLE
remove oneEach restriction

### DIFF
--- a/src/main/resources/hudson/plugins/view/dashboard/Dashboard/configure-entries.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/Dashboard/configure-entries.jelly
@@ -55,8 +55,7 @@ THE SOFTWARE.
       <f:hetero-list name="topPortlet" hasHeader="true"
                      descriptors="${descriptors}"
                      items="${it.topPortlets}"
-                     addCaption="${%Add Dashboard Portlet to the top of the view}"
-                     oneEach="true"/>
+                     addCaption="${%Add Dashboard Portlet to the top of the view}"/>
     </f:block>
   </f:section>
   <f:section title="${%Portlets in the left column}">
@@ -64,8 +63,7 @@ THE SOFTWARE.
       <f:hetero-list name="leftPortlet" hasHeader="true"
                      descriptors="${descriptors}"
                      items="${it.leftPortlets}"
-                     addCaption="${%Add Dashboard Portlet to left column}"
-                     oneEach="true"/>
+                     addCaption="${%Add Dashboard Portlet to left column}"/>
     </f:block>
   </f:section>
   <f:section title="${%Portlets in the right column}">
@@ -73,8 +71,7 @@ THE SOFTWARE.
       <f:hetero-list name="rightPortlet" hasHeader="true"
                      descriptors="${descriptors}"
                      items="${it.rightPortlets}"
-                     addCaption="${%Add Dashboard Portlet to right column}"
-                     oneEach="true"/>
+                     addCaption="${%Add Dashboard Portlet to right column}"/>
     </f:block>
   </f:section>
   <f:section title="${%Portlets at the bottom of the page}">
@@ -82,8 +79,7 @@ THE SOFTWARE.
       <f:hetero-list name="bottomPortlet" hasHeader="true"
                      descriptors="${descriptors}"
                      items="${it.bottomPortlets}"
-                     addCaption="${%Add Dashboard Portlet to bottom of the view}"
-                     oneEach="true"/>
+                     addCaption="${%Add Dashboard Portlet to bottom of the view}"/>
     </f:block>
     <p/>
   </f:section>


### PR DESCRIPTION
It is absolutely valid to have multiple iframes or images per area so remove the oneEach restriction

fixes #366 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
