### PR TITLE
JENKINS-35414: Folders don't show up in dashboard view

### DIFF
--- a/src/main/resources/hudson/plugins/view/dashboard/Dashboard/main.jelly
+++ b/src/main/resources/hudson/plugins/view/dashboard/Dashboard/main.jelly
@@ -45,7 +45,7 @@
       </j:choose>
 
       <j:if test="${it.isIncludeStdJobList()}">
-        <t:projectView jobs="${it.jobs}" showViewTabs="true" columnExtensions="${it.columns}" indenter="${it.indenter}"
+        <t:projectView jobs="${it.items}" showViewTabs="true" columnExtensions="${it.columns}" indenter="${it.indenter}"
                        itemGroup="${it.owner.itemGroup}"/>
       </j:if>
       <j:if test="${!empty(it.leftPortlets) &amp;&amp; !empty(it.rightPortlets)}">


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fix for #212
This makes the Folders appear again when the `Show standard Jenkins list at the top of the page` is activated. The standard project list can obviously show items other that just jobs so `jobs="${it.jobs}"` is too restrictive.


### Testing done
Tested manually by adding a Folder to my Dashboard. Did show properly and no warnings or errors were logged.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
